### PR TITLE
태그 카테고리 화면: 네트워크 요청 + 뷰 표시 (Pinterest 형식)

### DIFF
--- a/PhotoTag/PhotoTag.xcodeproj/project.pbxproj
+++ b/PhotoTag/PhotoTag.xcodeproj/project.pbxproj
@@ -86,6 +86,12 @@
 		6A7C0576255C033300037184 /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7C0575255C033300037184 /* UIImage.swift */; };
 		6A7C0580255C081400037184 /* CGFloat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7C057F255C081400037184 /* CGFloat.swift */; };
 		6A7C0585255C086200037184 /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7C0584255C086200037184 /* UIView.swift */; };
+		6A87E231258B35AC00896BD6 /* TagCategoryLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A87E230258B35AC00896BD6 /* TagCategoryLayout.swift */; };
+		6A87E235258B534F00896BD6 /* TagCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A87E234258B534F00896BD6 /* TagCategoryViewModel.swift */; };
+		6A87E239258B594500896BD6 /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A87E238258B594500896BD6 /* Tag.swift */; };
+		6A87E243258B596300896BD6 /* PhotoNotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A87E242258B596300896BD6 /* PhotoNotes.swift */; };
+		6A87E247258B5E2400896BD6 /* TagCategoryCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A87E246258B5E2400896BD6 /* TagCategoryCellViewModel.swift */; };
+		6A87E252258B9B1A00896BD6 /* ImageLoadTaskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A87E251258B9B1A00896BD6 /* ImageLoadTaskManager.swift */; };
 		6A89B9B225546444003E1027 /* PhotoNoteCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A89B9B125546444003E1027 /* PhotoNoteCoordinator.swift */; };
 		6A89B9B725546463003E1027 /* SearchCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A89B9B625546463003E1027 /* SearchCoordinator.swift */; };
 		6A89B9BF25547088003E1027 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A89B9BE25547088003E1027 /* SearchViewController.swift */; };
@@ -169,6 +175,12 @@
 		6A7C0575255C033300037184 /* UIImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImage.swift; sourceTree = "<group>"; };
 		6A7C057F255C081400037184 /* CGFloat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGFloat.swift; sourceTree = "<group>"; };
 		6A7C0584255C086200037184 /* UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
+		6A87E230258B35AC00896BD6 /* TagCategoryLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCategoryLayout.swift; sourceTree = "<group>"; };
+		6A87E234258B534F00896BD6 /* TagCategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCategoryViewModel.swift; sourceTree = "<group>"; };
+		6A87E238258B594500896BD6 /* Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tag.swift; sourceTree = "<group>"; };
+		6A87E242258B596300896BD6 /* PhotoNotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoNotes.swift; sourceTree = "<group>"; };
+		6A87E246258B5E2400896BD6 /* TagCategoryCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCategoryCellViewModel.swift; sourceTree = "<group>"; };
+		6A87E251258B9B1A00896BD6 /* ImageLoadTaskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoadTaskManager.swift; sourceTree = "<group>"; };
 		6A89B9B125546444003E1027 /* PhotoNoteCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoNoteCoordinator.swift; sourceTree = "<group>"; };
 		6A89B9B625546463003E1027 /* SearchCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCoordinator.swift; sourceTree = "<group>"; };
 		6A89B9BE25547088003E1027 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
@@ -312,6 +324,8 @@
 		6A7C055B255C00E300037184 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
+				6A87E234258B534F00896BD6 /* TagCategoryViewModel.swift */,
+				6A87E246258B5E2400896BD6 /* TagCategoryCellViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -342,6 +356,7 @@
 				6AD3ED6625519FE900F8EF61 /* UseCase.swift */,
 				6AD3ED6B2551A09900F8EF61 /* HTTPMethod.swift */,
 				6AD3ED702551A0B400F8EF61 /* NetworkError.swift */,
+				6A87E251258B9B1A00896BD6 /* ImageLoadTaskManager.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -380,6 +395,7 @@
 				6A5544FD255AD575003F3864 /* TagCategoryCollectionViewCell.swift */,
 				6A5544FE255AD575003F3864 /* TagCategoryCollectionViewCell.xib */,
 				6A63BA1E255C1F450096A0F7 /* TagCategoryCollectionViewDataSource.swift */,
+				6A87E230258B35AC00896BD6 /* TagCategoryLayout.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -454,6 +470,8 @@
 			children = (
 				6ACCADBC256E28BE00072290 /* Hashtags.swift */,
 				6A761E3C258A65F000E0E0F4 /* TagNetworkingManager.swift */,
+				6A87E238258B594500896BD6 /* Tag.swift */,
+				6A87E242258B596300896BD6 /* PhotoNotes.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -701,22 +719,27 @@
 			files = (
 				6AD3ED6225519F9E00F8EF61 /* NetworkManager.swift in Sources */,
 				6A89B9D2255473C9003E1027 /* ChildCoordinator.swift in Sources */,
+				6A87E231258B35AC00896BD6 /* TagCategoryLayout.swift in Sources */,
 				6A89B9E825549764003E1027 /* WritePhotoNoteViewController.swift in Sources */,
 				6A6825332548384700B19C9A /* LayoutGuideCompatible.swift in Sources */,
 				6A6825222548053F00B19C9A /* TagManagementViewController.swift in Sources */,
+				6A87E243258B596300896BD6 /* PhotoNotes.swift in Sources */,
 				6A761E3D258A65F000E0E0F4 /* TagNetworkingManager.swift in Sources */,
 				6AB83AE02542B4340065B698 /* Coordinator.swift in Sources */,
 				6A7C056C255C022200037184 /* UICollectionView.swift in Sources */,
 				6A89B9B725546463003E1027 /* SearchCoordinator.swift in Sources */,
+				6A87E239258B594500896BD6 /* Tag.swift in Sources */,
 				6AB83AF425442B370065B698 /* TagCoordinator.swift in Sources */,
 				6AA9BD65254E93C200126749 /* LoginManager.swift in Sources */,
 				6A682539254854E200B19C9A /* AppViewControllersFactory.swift in Sources */,
 				6AD3ED6C2551A09900F8EF61 /* HTTPMethod.swift in Sources */,
+				6A87E247258B5E2400896BD6 /* TagCategoryCellViewModel.swift in Sources */,
 				6A89B9B225546444003E1027 /* PhotoNoteCoordinator.swift in Sources */,
 				6AD3ED6725519FE900F8EF61 /* UseCase.swift in Sources */,
 				6AFE3C05253EDF3200B385AC /* LoginViewController.swift in Sources */,
 				6A554505255AE449003F3864 /* ContentViewWithHeader.swift in Sources */,
 				6A68254425485DA300B19C9A /* LoginView.swift in Sources */,
+				6A87E235258B534F00896BD6 /* TagCategoryViewModel.swift in Sources */,
 				6A7C0571255C029E00037184 /* NSObject.swift in Sources */,
 				6A7C054E255B93A000037184 /* TagManagementTableViewCell.swift in Sources */,
 				6A4F23F72546EC8A00577718 /* PhotoNoteListViewController.swift in Sources */,
@@ -728,6 +751,7 @@
 				6A343C8025735C8C00146AAF /* TagManagementCellViewModel.swift in Sources */,
 				6A89B9BF25547088003E1027 /* SearchViewController.swift in Sources */,
 				6A7C0585255C086200037184 /* UIView.swift in Sources */,
+				6A87E252258B9B1A00896BD6 /* ImageLoadTaskManager.swift in Sources */,
 				6A5544FF255AD575003F3864 /* TagCategoryCollectionViewCell.swift in Sources */,
 				6AB83AF925442C030065B698 /* TagCategoryViewController.swift in Sources */,
 				6ACCADBD256E28BE00072290 /* Hashtags.swift in Sources */,

--- a/PhotoTag/PhotoTag.xcodeproj/project.pbxproj
+++ b/PhotoTag/PhotoTag.xcodeproj/project.pbxproj
@@ -92,6 +92,9 @@
 		6A87E243258B596300896BD6 /* PhotoNotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A87E242258B596300896BD6 /* PhotoNotes.swift */; };
 		6A87E247258B5E2400896BD6 /* TagCategoryCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A87E246258B5E2400896BD6 /* TagCategoryCellViewModel.swift */; };
 		6A87E252258B9B1A00896BD6 /* ImageLoadTaskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A87E251258B9B1A00896BD6 /* ImageLoadTaskManager.swift */; };
+		6A87E258258C768F00896BD6 /* MockTags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A87E257258C768F00896BD6 /* MockTags.swift */; };
+		6A87E25B258C773100896BD6 /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A87E238258B594500896BD6 /* Tag.swift */; };
+		6A87E25E258C7B4000896BD6 /* MockTags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A87E257258C768F00896BD6 /* MockTags.swift */; };
 		6A89B9B225546444003E1027 /* PhotoNoteCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A89B9B125546444003E1027 /* PhotoNoteCoordinator.swift */; };
 		6A89B9B725546463003E1027 /* SearchCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A89B9B625546463003E1027 /* SearchCoordinator.swift */; };
 		6A89B9BF25547088003E1027 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A89B9BE25547088003E1027 /* SearchViewController.swift */; };
@@ -118,6 +121,12 @@
 		6AD3ED6C2551A09900F8EF61 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD3ED6B2551A09900F8EF61 /* HTTPMethod.swift */; };
 		6AD3ED712551A0B400F8EF61 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD3ED702551A0B400F8EF61 /* NetworkError.swift */; };
 		6AE1245E256830A300291388 /* UISwipeGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE1245D256830A300291388 /* UISwipeGestureRecognizer.swift */; };
+		6AEC28AE259223CC00D0634A /* URLComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEC28AD259223CC00D0634A /* URLComponents.swift */; };
+		6AEC28B12592398500D0634A /* TagCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A87E234258B534F00896BD6 /* TagCategoryViewModel.swift */; };
+		6AEC28B42592398C00D0634A /* TagCategoryLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A87E230258B35AC00896BD6 /* TagCategoryLayout.swift */; };
+		6AEC28B7259239AE00D0634A /* TagCategoryCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A87E246258B5E2400896BD6 /* TagCategoryCellViewModel.swift */; };
+		6AEC28BA259239B400D0634A /* ImageLoadTaskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A87E251258B9B1A00896BD6 /* ImageLoadTaskManager.swift */; };
+		6AEC28BD259239BA00D0634A /* URLComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEC28AD259223CC00D0634A /* URLComponents.swift */; };
 		6AFE3C01253EDF3200B385AC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AFE3C00253EDF3200B385AC /* AppDelegate.swift */; };
 		6AFE3C05253EDF3200B385AC /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AFE3C04253EDF3200B385AC /* LoginViewController.swift */; };
 		6AFE3C0B253EDF3200B385AC /* PhotoTag.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 6AFE3C09253EDF3200B385AC /* PhotoTag.xcdatamodeld */; };
@@ -181,6 +190,7 @@
 		6A87E242258B596300896BD6 /* PhotoNotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoNotes.swift; sourceTree = "<group>"; };
 		6A87E246258B5E2400896BD6 /* TagCategoryCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCategoryCellViewModel.swift; sourceTree = "<group>"; };
 		6A87E251258B9B1A00896BD6 /* ImageLoadTaskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoadTaskManager.swift; sourceTree = "<group>"; };
+		6A87E257258C768F00896BD6 /* MockTags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTags.swift; sourceTree = "<group>"; };
 		6A89B9B125546444003E1027 /* PhotoNoteCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoNoteCoordinator.swift; sourceTree = "<group>"; };
 		6A89B9B625546463003E1027 /* SearchCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCoordinator.swift; sourceTree = "<group>"; };
 		6A89B9BE25547088003E1027 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
@@ -206,6 +216,7 @@
 		6AD3ED6B2551A09900F8EF61 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		6AD3ED702551A0B400F8EF61 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		6AE1245D256830A300291388 /* UISwipeGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UISwipeGestureRecognizer.swift; sourceTree = "<group>"; };
+		6AEC28AD259223CC00D0634A /* URLComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLComponents.swift; sourceTree = "<group>"; };
 		6AFE3BFD253EDF3200B385AC /* PhotoTag.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoTag.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6AFE3C00253EDF3200B385AC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		6AFE3C04253EDF3200B385AC /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
@@ -344,6 +355,7 @@
 				6AE1245D256830A300291388 /* UISwipeGestureRecognizer.swift */,
 				6AD3ED5C25519F5700F8EF61 /* URLRequest.swift */,
 				6AAB872125849A1B00D1F3B1 /* NotificationName.swift */,
+				6AEC28AD259223CC00D0634A /* URLComponents.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -523,6 +535,7 @@
 				6AFE3C1A253EDF3400B385AC /* PhotoTagTests.swift */,
 				6AAB873D258A1F9B00D1F3B1 /* MockHashtags.swift */,
 				6A761E6B258A693E00E0E0F4 /* Info.plist */,
+				6A87E257258C768F00896BD6 /* MockTags.swift */,
 			);
 			path = PhotoTagTests;
 			sourceTree = "<group>";
@@ -742,6 +755,7 @@
 				6A87E235258B534F00896BD6 /* TagCategoryViewModel.swift in Sources */,
 				6A7C0571255C029E00037184 /* NSObject.swift in Sources */,
 				6A7C054E255B93A000037184 /* TagManagementTableViewCell.swift in Sources */,
+				6A87E25E258C7B4000896BD6 /* MockTags.swift in Sources */,
 				6A4F23F72546EC8A00577718 /* PhotoNoteListViewController.swift in Sources */,
 				6A5544DC2559B3BB003F3864 /* ContentView.swift in Sources */,
 				6A63BA1A255C1ED40096A0F7 /* TagManagementTableViewDataSource.swift in Sources */,
@@ -769,6 +783,7 @@
 				6A63BA2C255C2F210096A0F7 /* TagManagementTableViewDelegate.swift in Sources */,
 				6A5544C925599CDF003F3864 /* UIColor.swift in Sources */,
 				6A5544E42559B3CA003F3864 /* ScrollableContentViewWithHeader.swift in Sources */,
+				6AEC28AE259223CC00D0634A /* URLComponents.swift in Sources */,
 				6AE1245E256830A300291388 /* UISwipeGestureRecognizer.swift in Sources */,
 				6A68255025497B7200B19C9A /* Shadow.swift in Sources */,
 				6AFE3C0B253EDF3200B385AC /* PhotoTag.xcdatamodeld in Sources */,
@@ -791,22 +806,27 @@
 				6A4AD141258A59C200857FEC /* TagManagementTableViewDataSource.swift in Sources */,
 				6A4AD1F8258A5B9200857FEC /* LoginManager.swift in Sources */,
 				6A4AD1E8258A5B6600857FEC /* TagCategoryView.swift in Sources */,
+				6AEC28BA259239B400D0634A /* ImageLoadTaskManager.swift in Sources */,
 				6A4DB69E258A6F5100B3A481 /* TagNetworkingManager.swift in Sources */,
 				6A4AD149258A59CA00857FEC /* TagCoordinator.swift in Sources */,
 				6A4AD189258A5AD900857FEC /* UsesAutoLayout.swift in Sources */,
 				6A4AD151258A59F900857FEC /* TagManagementTableViewCell.swift in Sources */,
 				6A4AD1E0258A5B4500857FEC /* SearchCoordinator.swift in Sources */,
+				6AEC28B42592398C00D0634A /* TagCategoryLayout.swift in Sources */,
 				6A4AD1CC258A5B2C00857FEC /* SelectPhotoViewController.swift in Sources */,
 				6A4AD1F4258A5B8A00857FEC /* TagManagementCellViewModel.swift in Sources */,
 				6A4AD171258A5A6800857FEC /* LayoutGuideCompatible.swift in Sources */,
 				6A4AD185258A5AD700857FEC /* UISwipeGestureRecognizer.swift in Sources */,
 				6A4AD1A5258A5AEA00857FEC /* UICollectionView.swift in Sources */,
+				6A87E25B258C773100896BD6 /* Tag.swift in Sources */,
 				6A4AD1A9258A5AF300857FEC /* Coordinator.swift in Sources */,
+				6AEC28B12592398500D0634A /* TagCategoryViewModel.swift in Sources */,
 				6A4AD1AD258A5AF800857FEC /* AppViewControllersFactory.swift in Sources */,
 				6A4AD139258A58C200857FEC /* TagManagementViewController.swift in Sources */,
 				6A4AD1C4258A5B1E00857FEC /* PhotoNoteCoordinator.swift in Sources */,
 				6A4AD179258A5AA100857FEC /* ChildCoordinator.swift in Sources */,
 				6A4AD17D258A5ACF00857FEC /* NotificationName.swift in Sources */,
+				6AEC28BD259239BA00D0634A /* URLComponents.swift in Sources */,
 				6A4AD1C0258A5B1A00857FEC /* TagCategoryViewController.swift in Sources */,
 				6A4AD1A1258A5AE700857FEC /* UITableView.swift in Sources */,
 				6A4AD19D258A5AE400857FEC /* NSObject.swift in Sources */,
@@ -814,8 +834,10 @@
 				6A4AD1D0258A5B3100857FEC /* WritePhotoNoteViewController.swift in Sources */,
 				6A4AD16D258A5A5300857FEC /* ContentView.swift in Sources */,
 				6A4AD155258A59FF00857FEC /* UseCase.swift in Sources */,
+				6AEC28B7259239AE00D0634A /* TagCategoryCellViewModel.swift in Sources */,
 				6A4AD169258A5A2F00857FEC /* ContentViewWithHeader.swift in Sources */,
 				6A4AD1EC258A5B7400857FEC /* TagCategoryCollectionViewCell.swift in Sources */,
+				6A87E258258C768F00896BD6 /* MockTags.swift in Sources */,
 				6A4AD175258A5A6D00857FEC /* Shadow.swift in Sources */,
 				6A4AD181258A5AD400857FEC /* URLRequest.swift in Sources */,
 				6A4AD1F0258A5B8600857FEC /* TagCategoryCollectionViewDataSource.swift in Sources */,

--- a/PhotoTag/PhotoTag/AppConfigurator/AppViewControllersFactory.swift
+++ b/PhotoTag/PhotoTag/AppConfigurator/AppViewControllersFactory.swift
@@ -17,7 +17,7 @@ struct AppViewControllersFactory {
     }
     
     func tagCategoryViewController(coordinator: TagCoordinator) -> UIViewController {
-        return TagCategoryViewController(coordinator: coordinator)
+        return TagCategoryViewController(with: TagCategoryViewModel(), coordinator: coordinator)
     }
     
     func tagManagementViewController(coordinator: TagCoordinator) -> UIViewController {

--- a/PhotoTag/PhotoTag/Login/Model/LoginManager.swift
+++ b/PhotoTag/PhotoTag/Login/Model/LoginManager.swift
@@ -24,7 +24,7 @@ final class LoginManager {
         return request
     }
     
-    // MARK: - functions
+    // MARK: - Functions
     func requestAppleLoginToken(credential: ASAuthorizationAppleIDCredential) {
         guard let tokenData = credential.identityToken,
               let token = String(data: tokenData, encoding: .utf8) else { return }

--- a/PhotoTag/PhotoTag/Network/Endpoint.swift
+++ b/PhotoTag/PhotoTag/Network/Endpoint.swift
@@ -20,12 +20,14 @@ struct Endpoint: RequestProviding {
         case appleLogin
         case fetchHashtags
         case patchHashtags
+        case fetchTagCategory
         
         var description: String {
             switch self {
             case .appleLogin: return "/apple-login"
             case .fetchHashtags: return "/tags/setting"
             case .patchHashtags: return "/tags/"
+            case .fetchTagCategory: return "/tags/explore"
             }
         }
     }
@@ -50,5 +52,23 @@ struct Endpoint: RequestProviding {
         var endpoint = Endpoint(path: path)
         endpoint.tagId = tagId
         return endpoint
+    }
+    
+    static func tagCategoryFetch(withSize: Int, page: Int) -> URLComponents {
+        let queryParams: [String: String] = [
+            "size": "\(withSize)",
+            "page": "\(page)",
+            "sort": "tagName"
+        ]
+        return makeURL(with: queryParams, path: .fetchTagCategory)
+    }
+    
+    static func makeURL(with parameters: [String: String], path: Path) -> URLComponents {
+        var urlComponents = URLComponents()
+        urlComponents.scheme = "http"
+        urlComponents.host = "52.78.129.236"
+        urlComponents.path = ":8080" + path.description
+        urlComponents.setQueryItems(with: parameters)
+        return urlComponents
     }
 }

--- a/PhotoTag/PhotoTag/Network/ImageLoadTaskManager.swift
+++ b/PhotoTag/PhotoTag/Network/ImageLoadTaskManager.swift
@@ -1,0 +1,22 @@
+//
+//  ImageLoadTaskManager.swift
+//  PhotoTag
+//
+//  Created by Keunna Lee on 2020/12/17.
+//
+
+import Foundation
+import Combine
+
+final class ImageLoadTaskManager {
+    
+    func fetchImage(with url: URL, completionHandler: @escaping (Data?) -> Void) {
+        UseCase.shared.request(type: Data.self, imageUrl: url)
+            .receive(subscriber: Subscribers.Sink(receiveCompletion: { [weak self] in
+                guard case let .failure(error) = $0 else { return }
+                debugPrint(error.localizedDescription)
+            }, receiveValue: { [weak self] data in
+                completionHandler(data)
+            }))
+    }
+}

--- a/PhotoTag/PhotoTag/Network/NetworkError.swift
+++ b/PhotoTag/PhotoTag/Network/NetworkError.swift
@@ -14,6 +14,7 @@ enum NetworkError: Error {
     case apiError
     case jsonEncodingError
     case jsonDecodingError
+    case noData
     
     var message: String {
         switch self {
@@ -25,6 +26,8 @@ enum NetworkError: Error {
             return "Invalid API"
         case .jsonEncodingError, .jsonDecodingError:
             return "Invalid JSON Format"
+        case .noData:
+            return "No Data"
         }
     }
 }

--- a/PhotoTag/PhotoTag/Network/NetworkManager.swift
+++ b/PhotoTag/PhotoTag/Network/NetworkManager.swift
@@ -24,7 +24,7 @@ struct NetworkManager: NetworkConnectable {
         self.session = session
     }
     
-    // MARK: - Methods
+    // MARK: - Functions
     func request(request: URLRequest) -> AnyPublisher<(data: Data, response: URLResponse), NetworkError> {
         session.dataTaskPublisher(for: request)
             .mapError { _ in NetworkError.apiError }

--- a/PhotoTag/PhotoTag/Network/UseCase.swift
+++ b/PhotoTag/PhotoTag/Network/UseCase.swift
@@ -66,4 +66,20 @@ struct UseCase {
             .eraseToAnyPublisher()
     }
     
+    // using URLComponents
+    func request<D: Decodable>(_ network: NetworkConnectable = NetworkManager.shared,
+                               type: D.Type, urlComponents: URLComponents,
+                               method: HTTPMethod) -> AnyPublisher<D, Error> {
+        guard let url = urlComponents.url else {
+            return Fail(error: NetworkError.urlError).eraseToAnyPublisher()
+        }
+        
+        return network
+            .session
+            .dataTaskPublisher(for: URLRequest(url: url, method: method))
+            .map { $0.data }
+            .decode(type: D.self, decoder: decoder)
+            .eraseToAnyPublisher()
+    }
+    
 }

--- a/PhotoTag/PhotoTag/Network/UseCase.swift
+++ b/PhotoTag/PhotoTag/Network/UseCase.swift
@@ -54,4 +54,16 @@ struct UseCase {
             .eraseToAnyPublisher()
     }
     
+    // for fetch image
+    func request<I: Decodable>(_ network: NetworkConnectable = NetworkManager.shared,
+                               type: I.Type, imageUrl: URL) -> AnyPublisher<I, Error> {
+
+        return network
+            .session
+            .dataTaskPublisher(for: URLRequest(url: imageUrl))
+            .map { $0.data }
+            .decode(type: I.self, decoder: decoder)
+            .eraseToAnyPublisher()
+    }
+    
 }

--- a/PhotoTag/PhotoTag/Network/UseCase.swift
+++ b/PhotoTag/PhotoTag/Network/UseCase.swift
@@ -17,7 +17,7 @@ struct UseCase {
     // MARK: - Lifecycle
     private init() { }
     
-    // MARK: - Methods
+    // MARK: - Functions
     func request<E: Encodable>(_ network: NetworkConnectable = NetworkManager.shared,
                                data: E,
                                endpoint: RequestProviding,

--- a/PhotoTag/PhotoTag/Tag/Model/PhotoNotes.swift
+++ b/PhotoTag/PhotoTag/Tag/Model/PhotoNotes.swift
@@ -1,0 +1,25 @@
+//
+//  PhotoNotes.swift
+//  PhotoTag
+//
+//  Created by Keunna Lee on 2020/12/17.
+//
+
+import Foundation
+
+struct PhotoNotes: Codable {
+    let notes: [Note]
+}
+
+struct Note: Codable {
+    let tagID, noteID: Int
+    let tags, photos: [String]
+    let created: Date
+    let rawMemo: String
+    
+    enum CodingKeys: String, CodingKey {
+        case tags, photos, created, rawMemo
+        case tagID = "tagId"
+        case noteID = "noteId"
+    }
+}

--- a/PhotoTag/PhotoTag/Tag/Model/Tag.swift
+++ b/PhotoTag/PhotoTag/Tag/Model/Tag.swift
@@ -8,14 +8,14 @@
 import Foundation
 
 struct Tag: Codable {
-    var thumbnailUrl: String
+    var thumbnail: String
     let frequency, tagID: Int
     let activated: Bool
     let tagName: String
     
     enum CodingKeys: String, CodingKey {
-        case frequency, tagName, activated
+        case activated, frequency
         case tagID = "tagId"
-        case thumbnailUrl = "thumbnail"
+        case tagName, thumbnail
     }
 }

--- a/PhotoTag/PhotoTag/Tag/Model/Tag.swift
+++ b/PhotoTag/PhotoTag/Tag/Model/Tag.swift
@@ -1,0 +1,21 @@
+//
+//  Tag.swift
+//  PhotoTag
+//
+//  Created by Keunna Lee on 2020/12/17.
+//
+
+import Foundation
+
+struct Tag: Codable {
+    var thumbnailUrl: String
+    let frequency, tagID: Int
+    let activated: Bool
+    let tagName: String
+    
+    enum CodingKeys: String, CodingKey {
+        case frequency, tagName, activated
+        case tagID = "tagId"
+        case thumbnailUrl = "thumbnail"
+    }
+}

--- a/PhotoTag/PhotoTag/Tag/Model/TagNetworkingManager.swift
+++ b/PhotoTag/PhotoTag/Tag/Model/TagNetworkingManager.swift
@@ -18,7 +18,7 @@ final class TagNetworkingManager {
     func fetchHashtags(completionHandler: @escaping (Hashtags?) -> Void) {
         UseCase.shared
             .request(type: Hashtags.self, endpoint: Endpoint(path: .fetchHashtags), method: .get)
-            .receive(subscriber: Subscribers.Sink(receiveCompletion: { [weak self] in
+            .receive(subscriber: Subscribers.Sink(receiveCompletion: { [ weak self ] in
                 guard case let .failure(error) = $0 else { return }
                 debugPrint(error.localizedDescription)
                 // TODO: - present alertController
@@ -31,7 +31,7 @@ final class TagNetworkingManager {
         UseCase.shared.request(data: data,
                                endpoint: Endpoint.hashtagPatch(path: .patchHashtags, tagId: tagId),
                                method: .patch)
-            .receive(subscriber: Subscribers.Sink(receiveCompletion: { [weak self] in
+            .receive(subscriber: Subscribers.Sink(receiveCompletion: { [ weak self ] in
                 guard case let .failure(error) = $0 else { return }
                 debugPrint(error.message)
             }, receiveValue: { [weak self] response in
@@ -40,15 +40,14 @@ final class TagNetworkingManager {
     }
     
     // MARK: - Tag Category
-    func fetchTagsWithImage(size: Int, page: Int,
+    func fetchTags(size: Int, page: Int,
                             completionHandler: @escaping ([Tag]?) -> Void) {
-        // /tags/explore?size=12&page=0&sort=tagName
         UseCase.shared
-            .request(type: [Tag].self, endpoint: Endpoint(path: .fetchHashtags), method: .get)
-            .receive(subscriber: Subscribers.Sink(receiveCompletion: { [weak self] in
+            .request(type: [Tag].self, urlComponents: Endpoint.tagCategoryFetch(withSize: size, page: page), method: .get)
+            .receive(subscriber: Subscribers.Sink(receiveCompletion: { [ weak self ] in
                 guard case let .failure(error) = $0 else { return }
                 debugPrint(error.localizedDescription)
-            }, receiveValue: { [weak self] data in
+            }, receiveValue: { [ weak self ] data in
                 completionHandler(data)
             }))
     }
@@ -57,7 +56,7 @@ final class TagNetworkingManager {
     private func checkResponseStatus(statusCode: Int) {
         if 200 == statusCode {
             debugPrint("요청이 성공했습니다")
-        } else if 204 == statusCode{
+        } else if 204 == statusCode {
             debugPrint("No Content. 콘텐츠가 없습니다")
         } else if 401 == statusCode {
             debugPrint("Unauthorized. 권한이 없습니다")

--- a/PhotoTag/PhotoTag/Tag/Model/TagNetworkingManager.swift
+++ b/PhotoTag/PhotoTag/Tag/Model/TagNetworkingManager.swift
@@ -14,6 +14,7 @@ struct HastagState: Codable {
 
 final class TagNetworkingManager {
     
+    // MARK: - Tag Management
     func fetchHashtags(completionHandler: @escaping (Hashtags?) -> Void) {
         UseCase.shared
             .request(type: Hashtags.self, endpoint: Endpoint(path: .fetchHashtags), method: .get)
@@ -38,6 +39,21 @@ final class TagNetworkingManager {
             }))
     }
     
+    // MARK: - Tag Category
+    func fetchTagsWithImage(size: Int, page: Int,
+                            completionHandler: @escaping ([Tag]?) -> Void) {
+        // /tags/explore?size=12&page=0&sort=tagName
+        UseCase.shared
+            .request(type: [Tag].self, endpoint: Endpoint(path: .fetchHashtags), method: .get)
+            .receive(subscriber: Subscribers.Sink(receiveCompletion: { [weak self] in
+                guard case let .failure(error) = $0 else { return }
+                debugPrint(error.localizedDescription)
+            }, receiveValue: { [weak self] data in
+                completionHandler(data)
+            }))
+    }
+    
+    // MARK: - Message
     private func checkResponseStatus(statusCode: Int) {
         if 200 == statusCode {
             debugPrint("요청이 성공했습니다")

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewCell.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewCell.swift
@@ -16,5 +16,14 @@ final class TagCategoryCollectionViewCell: UICollectionViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
     }
+    
+    func fill(with tag: Tag) {
+        tagNameLabel.text = tag.tagName
+        noteCountLabel.text = "\(tag.frequency) note(s)"
+    }
+    
+    func fillImage(with image: UIImage) {
+        latestImageView.image = image
+    }
 
 }

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewDataSource.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewDataSource.swift
@@ -16,14 +16,14 @@ final class TagCategoryCollectionViewDataSource: NSObject, UICollectionViewDataS
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return viewModel.tagsWithImage.value.count
+        return viewModel.tags.value.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let collectionViewCell = collectionView.dequeueReusableCell(with: TagCategoryCollectionViewCell.self, for: indexPath)
         bind(with: collectionViewCell)
-        if viewModel.tagsWithImage.value.count != 0, viewModel.tagImages.value.count != 0 {
-            collectionViewCell.fill(with: self.viewModel.tagsWithImage.value[indexPath.item])
+        if viewModel.tags.value.count != 0, self.viewModel.tagImages.value.count != 0 {
+            collectionViewCell.fill(with: self.viewModel.tags.value[indexPath.item])
             collectionViewCell.fillImage(with: self.viewModel.tagImages.value[indexPath.item])
         }
         return collectionViewCell
@@ -33,24 +33,18 @@ final class TagCategoryCollectionViewDataSource: NSObject, UICollectionViewDataS
 
 extension TagCategoryCollectionViewDataSource {
     func updateViewModel(updatedViewModel: TagCategoryViewModel) {
-        self.viewModel = updatedViewModel
     }
     
     private func bind(with cell: TagCategoryCollectionViewCell) {
         let cellViewModel = TagCategoryCellViewModel()
         cellViewModel.noteCountLabelText.bind { noteCount in
-            cell.noteCountLabel.text = "\(noteCount) note(s)"
+            cell.noteCountLabel.text = "\(noteCount)"
         }
         cellViewModel.tagNameLabelText.bind { tagName in
             cell.tagNameLabel.text = tagName
         }
-        cellViewModel.latestImageViewUrl.bind { imageUrl in
-            guard let url = URL(string: imageUrl) else { return }
-            
-            cellViewModel.updateTagImage(with: url) { image in
-                cellViewModel.image.value = image
-                self.viewModel.addImage(newImage: image)
-            }
+        cellViewModel.image.bind { image in
+            cell.latestImageView.image = image
         }
     }
 }

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewDataSource.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewDataSource.swift
@@ -8,19 +8,49 @@
 import UIKit
 
 final class TagCategoryCollectionViewDataSource: NSObject, UICollectionViewDataSource {
-
+    
+    private var viewModel = TagCategoryViewModel()
+    
     func numberOfSections(in collectionView: UICollectionView) -> Int {
         return TagCategoryCollectionViewConstant.numberOfSections
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 150 // 추후 변경 예정입니다.
+        return viewModel.tagsWithImage.value.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let collectionViewCell = collectionView.dequeueReusableCell(with: TagCategoryCollectionViewCell.self, for: indexPath)
-        collectionViewCell.backgroundColor = .blue
+        bind(with: collectionViewCell)
+        if viewModel.tagsWithImage.value.count != 0, viewModel.tagImages.value.count != 0 {
+            collectionViewCell.fill(with: self.viewModel.tagsWithImage.value[indexPath.item])
+            collectionViewCell.fillImage(with: self.viewModel.tagImages.value[indexPath.item])
+        }
         return collectionViewCell
     }
     
+}
+
+extension TagCategoryCollectionViewDataSource {
+    func updateViewModel(updatedViewModel: TagCategoryViewModel) {
+        self.viewModel = updatedViewModel
+    }
+    
+    private func bind(with cell: TagCategoryCollectionViewCell) {
+        let cellViewModel = TagCategoryCellViewModel()
+        cellViewModel.noteCountLabelText.bind { noteCount in
+            cell.noteCountLabel.text = "\(noteCount) note(s)"
+        }
+        cellViewModel.tagNameLabelText.bind { tagName in
+            cell.tagNameLabel.text = tagName
+        }
+        cellViewModel.latestImageViewUrl.bind { imageUrl in
+            guard let url = URL(string: imageUrl) else { return }
+            
+            cellViewModel.updateTagImage(with: url) { image in
+                cellViewModel.image.value = image
+                self.viewModel.addImage(newImage: image)
+            }
+        }
+    }
 }

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryLayout.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryLayout.swift
@@ -1,0 +1,82 @@
+//
+//  TagCategoryLayout.swift
+//  PhotoTag
+//
+//  Created by Keunna Lee on 2020/12/17.
+//
+
+import UIKit
+
+protocol TagCategoryLayoutDelegate: class {
+  func collectionView(_ collectionView: UICollectionView, heightForPhotoAtIndexPath indexPath: IndexPath) -> CGFloat
+}
+
+class TagCategoryLayout: UICollectionViewLayout {
+    
+    // MARK: - Properties
+    weak var delegate: TagCategoryLayoutDelegate?
+    private let numberOfColumns = 2
+    private let cellPadding: CGFloat = 6
+    private var attributesCache: [UICollectionViewLayoutAttributes] = []
+    private var contentHeight: CGFloat = 0
+    private let defaultContentHeight: CGFloat = 180
+    private var contentWidth: CGFloat {
+      guard let collectionView = collectionView else {
+        return 0
+      }
+      let insets = collectionView.contentInset
+      return collectionView.bounds.width - (insets.left + insets.right)
+    }
+    override var collectionViewContentSize: CGSize {
+        return CGSize(width: contentWidth, height: contentHeight)
+    }
+    
+    // MARK: - Functions
+    // Whenever a layout operation is about to take place, UIKit calls prepare() function. In here, prepare and perform any calculations required to determine the collection view’s size and the positions of the items.
+    override func prepare() {
+        guard attributesCache.isEmpty, let collectionView = collectionView else { return }
+        
+        let columnWidth = contentWidth / CGFloat(numberOfColumns)
+        var xOffset: [CGFloat] = []
+        for column in 0..<numberOfColumns {
+            xOffset.append(CGFloat(column) * columnWidth)
+        }
+        var column = 0
+        var yOffset: [CGFloat] = .init(repeating: 0, count: numberOfColumns)
+        
+        for item in 0..<collectionView.numberOfItems(inSection: 0) {
+            let indexPath = IndexPath(item: item, section: 0)
+            
+            let photoHeight = delegate?.collectionView(collectionView, heightForPhotoAtIndexPath: indexPath) ?? defaultContentHeight
+            let height = cellPadding * 2 + photoHeight
+            let frame = CGRect(x: xOffset[column], y: yOffset[column], width: columnWidth, height: height)
+            let insetFrame = frame.insetBy(dx: cellPadding, dy: cellPadding)
+            
+            let attributes = UICollectionViewLayoutAttributes(forCellWith: indexPath) // set the frame for each item
+            attributes.frame = insetFrame
+            attributesCache.append(attributes)
+            
+            contentHeight = max(contentHeight, frame.maxY)
+            yOffset[column] = yOffset[column] + height
+            column = column < (numberOfColumns - 1) ? (column + 1) : 0
+        }
+        
+    }
+    
+    // Collection view calls this function after prepare() to determine which items are visible in the given rectangle. It return the layout attributes for all items insdie the given rectangle.
+    override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+        var visibleLayoutAttributes: [UICollectionViewLayoutAttributes] = []
+        
+        for attributes in attributesCache {
+            if attributes.frame.intersects(rect) {
+                visibleLayoutAttributes.append(attributes)
+            }
+        }
+        return visibleLayoutAttributes
+    }
+    
+    // This function returns the layout attributes for the item at the requested indexPath. It provides on demand layout information to the collection view.
+    override func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+        return attributesCache[indexPath.item]
+    }
+}

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryView.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryView.swift
@@ -21,9 +21,9 @@ final class TagCategoryView: ContentViewWithHeader {
     
     // MARK: - Properties
     @UsesAutoLayout var titleLabel = SubviewFactory.titleLabel()
-    @UsesAutoLayout private var moveToTagManagementButton = SubviewFactory.moveToTagManagementButton()
-    @UsesAutoLayout private var moveToPhotoListButton = SubviewFactory.moveToPhotoListButton()
-    @UsesAutoLayout private(set) var tagCategoryCollectionView = SubviewFactory.tagCategoryCollectionView()
+    @UsesAutoLayout var moveToTagManagementButton = SubviewFactory.moveToTagManagementButton()
+    @UsesAutoLayout var moveToPhotoListButton = SubviewFactory.moveToPhotoListButton()
+    @UsesAutoLayout var tagCategoryCollectionView = SubviewFactory.tagCategoryCollectionView()
     weak var delegate: TagCategoryViewDelegate?
     
     // MARK: - Intialization
@@ -124,6 +124,7 @@ private extension TagCategoryView {
             let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
             collectionView.register(cellType: TagCategoryCollectionViewCell.self)
             collectionView.contentInset = UIEdgeInsets(top: 23, left: 16, bottom: 10, right: 16)
+            collectionView.backgroundColor = .clear
             return collectionView
         }
         

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryView.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryView.swift
@@ -20,7 +20,7 @@ final class TagCategoryView: ContentViewWithHeader {
     }
     
     // MARK: - Properties
-    @UsesAutoLayout private var titleLabel = SubviewFactory.titleLabel()
+    @UsesAutoLayout var titleLabel = SubviewFactory.titleLabel()
     @UsesAutoLayout private var moveToTagManagementButton = SubviewFactory.moveToTagManagementButton()
     @UsesAutoLayout private var moveToPhotoListButton = SubviewFactory.moveToPhotoListButton()
     @UsesAutoLayout private(set) var tagCategoryCollectionView = SubviewFactory.tagCategoryCollectionView()
@@ -123,6 +123,7 @@ private extension TagCategoryView {
             let layout = UICollectionViewFlowLayout()
             let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
             collectionView.register(cellType: TagCategoryCollectionViewCell.self)
+            collectionView.contentInset = UIEdgeInsets(top: 23, left: 16, bottom: 10, right: 16)
             return collectionView
         }
         

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryViewController.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryViewController.swift
@@ -75,6 +75,31 @@ final class TagCategoryViewController: UIViewController {
     private func navigateToPhotoNoteList() {
         coordinator?.navigateToPhotoNoteList()
     }
+    
+    
+    private func bind() {
+        viewModel.title.bind { [weak self] sceneTitle in
+            self?.tagCategoryView.titleLabel.text = sceneTitle
+        }
+    }
+    
+    private func fetchTags() {
+        viewModel.fetchTags(size: requestTagDataSize, page: requestTagDataPageNumber) { fetchedViewModel in
+            self.dataSource.updateViewModel(updatedViewModel: fetchedViewModel)
+            self.updateTags()
+        }
+    }
+    
+    private func updateTags() {
+        DispatchQueue.main.async {
+            self.tagCategoryView.tagCategoryCollectionView.reloadData()
+        }
+    }
+    
+    @objc private func updateCollectionView() {
+        updateTags()
+    }
+    
 }
 
 extension TagCategoryViewController: TagCategoryViewDelegate {

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryViewController.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryViewController.swift
@@ -17,14 +17,16 @@ final class TagCategoryViewController: UIViewController {
     // MARK: - Properties
     private let dataSource = TagCategoryCollectionViewDataSource()
     weak var coordinator: TagCoordinator?
+    private let viewModel: TagCategoryViewModel
     private var tagCategoryView: TagCategoryView! {
         return view as? TagCategoryView
     }
     
     // MARK: - Intialization
     //TODO:- add viewModel as parameter
-    init(coordinator: TagCoordinator) {
+    init(with viewModel: TagCategoryViewModel, coordinator: TagCoordinator) {
         self.coordinator = coordinator
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -36,21 +38,31 @@ final class TagCategoryViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        // TODO: - request data from API
+        fetchTags()
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        bind()
+        fetchTags()
         configure()
     }
     
     // MARK: - Functions
     private func configure () {
         hideNavigationBar()
-        tagCategoryView.delegate = self
-        // TODO: - navigate to tutorial scene
-        tagCategoryView.tagCategoryCollectionView.dataSource = dataSource
+        tagCategoryView.delegate = self // TagCategoryViewDelegate
+        setupCollectionView()
     }
+    
+    private func setupCollectionView() {
+        let collectionView = tagCategoryView.tagCategoryCollectionView
+        collectionView.delegate = self // UICollectionViewDelegateFlowLayout
+        collectionView.dataSource = dataSource
+        if let layout = collectionView.collectionViewLayout as? TagCategoryLayout {
+          layout.delegate = self // TagCategoryLayoutDelegate
+        }
+      }
     
     private func hideNavigationBar() {
         self.navigationController?.isNavigationBarHidden = true
@@ -64,12 +76,27 @@ final class TagCategoryViewController: UIViewController {
         coordinator?.navigateToPhotoNoteList()
     }
 }
+
 extension TagCategoryViewController: TagCategoryViewDelegate {
     func moveToTagManagementButtonDidTouched(_ tagCategoryView: TagCategoryView) {
         navigateToTagManagement()
     }
+    
     func moveToPhotoListButtonDidTouched(_ tagCategoryView: TagCategoryView) {
         navigateToPhotoNoteList()
     }
     
+}
+
+extension TagCategoryViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let itemSize = (collectionView.frame.width - (collectionView.contentInset.left + collectionView.contentInset.right + 10)) / 2
+        return CGSize(width: itemSize, height: itemSize)
+    }
+}
+
+extension TagCategoryViewController: TagCategoryLayoutDelegate {
+    func collectionView(_ collectionView: UICollectionView, heightForPhotoAtIndexPath indexPath: IndexPath) -> CGFloat {
+        return viewModel.tagImages.value[indexPath.item].size.height
+    }
 }

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryViewController.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryViewController.swift
@@ -13,7 +13,7 @@ enum TagCategoryCollectionViewConstant {
 }
 
 final class TagCategoryViewController: UIViewController {
-        
+    
     // MARK: - Properties
     private let dataSource = TagCategoryCollectionViewDataSource()
     weak var coordinator: TagCoordinator?
@@ -23,6 +23,7 @@ final class TagCategoryViewController: UIViewController {
     private var requestTagDataPageNumber: Int {
         return requestTagDataSize * requestTime
     }
+    private var viewAppeard = false
     private var tagCategoryView: TagCategoryView! {
         return view as? TagCategoryView
     }
@@ -34,7 +35,7 @@ final class TagCategoryViewController: UIViewController {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
-
+    
     required init?(coder aDecoder: NSCoder) { return nil }
     
     // MARK: - Life Cycle
@@ -42,16 +43,12 @@ final class TagCategoryViewController: UIViewController {
         view = TagCategoryView()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        fetchTags()
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         bind()
-        fetchTags()
-        updateRequestTime()
         configure()
+        fetchTags()
+        viewAppeard = true
     }
     
     // MARK: - Functions
@@ -65,10 +62,12 @@ final class TagCategoryViewController: UIViewController {
         let collectionView = tagCategoryView.tagCategoryCollectionView
         collectionView.delegate = self // UICollectionViewDelegateFlowLayout
         collectionView.dataSource = dataSource
+        collectionView.showsVerticalScrollIndicator = false
         if let layout = collectionView.collectionViewLayout as? TagCategoryLayout {
-          layout.delegate = self // TagCategoryLayoutDelegate
+            layout.delegate = self // TagCategoryLayoutDelegate
+            tagCategoryView.backgroundColor = .white
         }
-      }
+    }
     
     private func hideNavigationBar() {
         self.navigationController?.isNavigationBarHidden = true
@@ -85,7 +84,6 @@ final class TagCategoryViewController: UIViewController {
     private func navigateToPhotoNoteList() {
         coordinator?.navigateToPhotoNoteList()
     }
-    
     
     private func bind() {
         viewModel.title.bind { [weak self] sceneTitle in
@@ -104,10 +102,6 @@ final class TagCategoryViewController: UIViewController {
         DispatchQueue.main.async {
             self.tagCategoryView.tagCategoryCollectionView.reloadData()
         }
-    }
-    
-    @objc private func updateCollectionView() {
-        updateTags()
     }
     
 }
@@ -138,11 +132,13 @@ extension TagCategoryViewController: TagCategoryLayoutDelegate {
 
 extension TagCategoryViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        let yOffset = scrollView.contentOffset.y
-        let contentHeight = scrollView.contentSize.height
-        if yOffset > contentHeight - scrollView.frame.height {
-            fetchTags()
-            updateRequestTime()
+        if viewAppeard {
+            let yOffset = scrollView.contentOffset.y
+            let contentHeight = scrollView.contentSize.height
+            if yOffset > contentHeight - scrollView.frame.height {
+                fetchTags()
+                updateRequestTime()
+            }
         }
     }
 }

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryViewController.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryViewController.swift
@@ -18,6 +18,11 @@ final class TagCategoryViewController: UIViewController {
     private let dataSource = TagCategoryCollectionViewDataSource()
     weak var coordinator: TagCoordinator?
     private let viewModel: TagCategoryViewModel
+    private let requestTagDataSize = 12
+    private var requestTime = 0
+    private var requestTagDataPageNumber: Int {
+        return requestTagDataSize * requestTime
+    }
     private var tagCategoryView: TagCategoryView! {
         return view as? TagCategoryView
     }
@@ -45,6 +50,7 @@ final class TagCategoryViewController: UIViewController {
         super.viewDidLoad()
         bind()
         fetchTags()
+        updateRequestTime()
         configure()
     }
     
@@ -66,6 +72,10 @@ final class TagCategoryViewController: UIViewController {
     
     private func hideNavigationBar() {
         self.navigationController?.isNavigationBarHidden = true
+    }
+    
+    private func updateRequestTime() {
+        self.requestTime = requestTime + 1
     }
     
     private func navigateToTagManagement() {
@@ -123,5 +133,16 @@ extension TagCategoryViewController: UICollectionViewDelegateFlowLayout {
 extension TagCategoryViewController: TagCategoryLayoutDelegate {
     func collectionView(_ collectionView: UICollectionView, heightForPhotoAtIndexPath indexPath: IndexPath) -> CGFloat {
         return viewModel.tagImages.value[indexPath.item].size.height
+    }
+}
+
+extension TagCategoryViewController: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let yOffset = scrollView.contentOffset.y
+        let contentHeight = scrollView.contentSize.height
+        if yOffset > contentHeight - scrollView.frame.height {
+            fetchTags()
+            updateRequestTime()
+        }
     }
 }

--- a/PhotoTag/PhotoTag/Tag/TagCategory/ViewModel/TagCategoryCellViewModel.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/ViewModel/TagCategoryCellViewModel.swift
@@ -10,18 +10,7 @@ import UIKit.UIImage
 
 final class TagCategoryCellViewModel {
     
-    let latestImageViewUrl = Observable("image url")
     let tagNameLabelText = Observable("tag name")
     let noteCountLabelText = Observable(0)
     let image: Observable<UIImage?> = Observable(nil)
-    let imageLoadTaskManager = ImageLoadTaskManager()
-}
-
-extension TagCategoryCellViewModel {
-    func updateTagImage(with url: URL, completionHandler: @escaping (UIImage) -> Void) {
-        imageLoadTaskManager.fetchImage(with: url) { imageData in
-            guard let data = imageData, let image = UIImage(data: data) else { return }
-            completionHandler(image)
-        }
-    }
 }

--- a/PhotoTag/PhotoTag/Tag/TagCategory/ViewModel/TagCategoryCellViewModel.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/ViewModel/TagCategoryCellViewModel.swift
@@ -1,0 +1,27 @@
+//
+//  TagCategoryCellViewModel.swift
+//  PhotoTag
+//
+//  Created by Keunna Lee on 2020/12/17.
+//
+
+import Foundation
+import UIKit.UIImage
+
+final class TagCategoryCellViewModel {
+    
+    let latestImageViewUrl = Observable("image url")
+    let tagNameLabelText = Observable("tag name")
+    let noteCountLabelText = Observable(0)
+    let image: Observable<UIImage?> = Observable(nil)
+    let imageLoadTaskManager = ImageLoadTaskManager()
+}
+
+extension TagCategoryCellViewModel {
+    func updateTagImage(with url: URL, completionHandler: @escaping (UIImage) -> Void) {
+        imageLoadTaskManager.fetchImage(with: url) { imageData in
+            guard let data = imageData, let image = UIImage(data: data) else { return }
+            completionHandler(image)
+        }
+    }
+}

--- a/PhotoTag/PhotoTag/Tag/TagCategory/ViewModel/TagCategoryViewModel.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/ViewModel/TagCategoryViewModel.swift
@@ -14,18 +14,43 @@ final class TagCategoryViewModel {
     let title = Observable("Tags")
     let tagImages: Observable<[UIImage]> = Observable([])
     let buttonText = Observable("Select Tag")
-    private(set) var tagsWithImage: Observable<[Tag]> = Observable([])
-
+    let imageLoadTaskManager = ImageLoadTaskManager()
+    private(set) var tags: Observable<[Tag]> = Observable([])
+    
     func fetchTags(size: Int, page: Int, completionHandler: @escaping (TagCategoryViewModel) -> Void) {
-        // modify limit and offset
-        tagNetworkManager.fetchTagsWithImage(size: 0, page: 0) { tags in
+        tagNetworkManager.fetchTags(size: size, page: page) { tags in
             guard let hashtags = tags else { return }
-            self.tagsWithImage = Observable(hashtags)
-            completionHandler(self)
+            self.updateTags(with: hashtags)
+            self.updateTagImages(with: hashtags) { viewModelWithImages in
+                completionHandler(viewModelWithImages)
+            }
+        }
+    }
+    
+    func updateTags(with hashtags: [Tag]) {
+        self.tags.value.append(contentsOf: hashtags)
+    }
+    
+    func updateTagImages(with hashtags: [Tag], completionHandler: @escaping (TagCategoryViewModel) -> Void) {
+        for tag in hashtags {
+            guard let thumbnailUrl = URL(string: tag.thumbnail) else { debugPrint("Invalid thumbnail Url."); return }
+            self.fetchTagImage(with: thumbnailUrl) { tagImage in
+                self.tagImages.value.append(tagImage)
+                completionHandler(self)
+            }
         }
     }
     
     func addImage(newImage: UIImage) {
         tagImages.value.append(newImage)
+    }
+}
+
+extension TagCategoryViewModel {
+    func fetchTagImage(with url: URL, completionHandler: @escaping (UIImage) -> Void) {
+        imageLoadTaskManager.fetchImage(with: url) { imageData in
+            guard let data = imageData, let image = UIImage(data: data) else { return }
+            completionHandler(image)
+        }
     }
 }

--- a/PhotoTag/PhotoTag/Tag/TagCategory/ViewModel/TagCategoryViewModel.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/ViewModel/TagCategoryViewModel.swift
@@ -1,0 +1,31 @@
+//
+//  TagCategoryViewModel.swift
+//  PhotoTag
+//
+//  Created by Keunna Lee on 2020/12/17.
+//
+
+import Foundation
+import UIKit.UIImage
+
+final class TagCategoryViewModel {
+    
+    let tagNetworkManager = TagNetworkingManager()
+    let title = Observable("Tags")
+    let tagImages: Observable<[UIImage]> = Observable([])
+    let buttonText = Observable("Select Tag")
+    private(set) var tagsWithImage: Observable<[Tag]> = Observable([])
+
+    func fetchTags(size: Int, page: Int, completionHandler: @escaping (TagCategoryViewModel) -> Void) {
+        // modify limit and offset
+        tagNetworkManager.fetchTagsWithImage(size: 0, page: 0) { tags in
+            guard let hashtags = tags else { return }
+            self.tagsWithImage = Observable(hashtags)
+            completionHandler(self)
+        }
+    }
+    
+    func addImage(newImage: UIImage) {
+        tagImages.value.append(newImage)
+    }
+}

--- a/PhotoTag/PhotoTag/Tag/TagManagement/View/TagManagementViewController.swift
+++ b/PhotoTag/PhotoTag/Tag/TagManagement/View/TagManagementViewController.swift
@@ -46,10 +46,6 @@ final class TagManagementViewController: UIViewController {
         view = TagManagementView()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        fetchHashtags()
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         setupNotification()

--- a/PhotoTag/PhotoTag/Utility/Extension/URLComponents.swift
+++ b/PhotoTag/PhotoTag/Utility/Extension/URLComponents.swift
@@ -1,0 +1,14 @@
+//
+//  URLComponents.swift
+//  PhotoTag
+//
+//  Created by Keunna Lee on 2020/12/22.
+//
+
+import Foundation
+
+extension URLComponents {
+    mutating func setQueryItems(with parameters: [String: String]) {
+        self.queryItems = parameters.map { URLQueryItem(name: $0.key, value: $0.value) }
+    }
+}

--- a/PhotoTag/PhotoTagTests/MockTags.swift
+++ b/PhotoTag/PhotoTagTests/MockTags.swift
@@ -1,0 +1,50 @@
+//
+//  MockTags.swift
+//  PhotoTagTests
+//
+//  Created by Keunna Lee on 2020/12/18.
+//
+
+import Foundation
+
+struct MockTags {
+    
+    private(set) var tagIdIndex = 0
+    private(set) var frequencyIndex = 0
+    private(set) var tagNameIndex = 0
+    private(set) var imageUrlIndex = 0
+    let tagIdList = [11, 13, 21, 41, 8, 3, 5, 33]
+    let frequencyList = [5, 11, 8, 10, 0, 4, 1, 2]
+    let tagNameList = ["travel", "career", "winter", "workOut", "nothing", "journey", "iceland", "winter"]
+    let imageUrls = ["https://cdn.pixabay.com/photo/2020/11/22/16/45/nutcracker-5767159_1280.jpg", "https://cdn.pixabay.com/photo/2019/12/19/10/56/christmas-market-4705882_1280.jpg", "https://cdn.pixabay.com/photo/2017/01/28/02/24/japan-2014619_1280.jpg","https://cdn.pixabay.com/photo/2017/10/10/21/49/youtuber-2838945_1280.jpg","https://cdn.pixabay.com/photo/2015/03/21/13/09/men-683660_1280.jpg","https://cdn.pixabay.com/photo/2015/12/16/03/45/korea-1095361_1280.jpg","https://cdn.pixabay.com/photo/2016/10/25/12/28/iceland-1768744_1280.jpg", "https://media.istockphoto.com/photos/reykjavik-capital-city-of-iceland-picture-id825428482", "https://cdn.pixabay.com/photo/2019/12/19/10/56/christmas-market-4705882_1280.jpg"]
+    let tags = [Tag]()
+    
+    mutating func makeMokeTags() -> [Tag] {
+        return [newTag(),newTag(),newTag(),newTag(),newTag(),newTag(),newTag(),newTag()]
+    }
+    
+    private func nextTagIdValue() -> Int {
+        return tagIdList[tagIdIndex]
+    }
+    
+    private func nextFrequencyValue() -> Int {
+        return frequencyList[frequencyIndex]
+    }
+    
+    private func nextTagName() -> String {
+        return tagNameList[tagNameIndex]
+    }
+    
+    private func nextImageUrl() -> String {
+        return imageUrls[imageUrlIndex]
+    }
+    
+    private mutating func newTag() -> Tag {
+        let newTag = Tag(thumbnail: nextImageUrl(), frequency: nextFrequencyValue(), tagID: nextTagIdValue(), activated: true, tagName: nextTagName())
+        self.tagIdIndex = tagIdIndex + 1
+        self.frequencyIndex = frequencyIndex + 1
+        self.tagNameIndex = tagNameIndex + 1
+        self.imageUrlIndex = imageUrlIndex + 1
+        return newTag
+    }
+}

--- a/PhotoTag/PhotoTagTests/PhotoTagTests.swift
+++ b/PhotoTag/PhotoTagTests/PhotoTagTests.swift
@@ -185,7 +185,39 @@ class PhotoTagTests: XCTestCase {
                         .contains(nonExistentTagId)
                        , "비활성화된(Archived) 해시태그 배열에 해당 태그 아이디를 가진 해시태그가 존재하지 않습니다.")
     }
-
+    
+    // MARK: - Network
+    func testMakeUrl() {
+        // given
+        let queryParams: [String: String] = [
+            "size": "\(12)",
+            "page": "\(0)",
+            "sort": "tagName"
+        ]
+        // when
+        let url = Endpoint.makeURL(with: queryParams, path: .fetchTagCategory)
+        let expectedUrl = URLComponents(string: "http://52.78.129.236:8080/tags/explore?size=12&page=0&sort=tagName")
+        // then
+        XCTAssertEqual(url.host, expectedUrl?.host, "url의 host가 일치합니다")
+        XCTAssertEqual(url.path, ":8080" + expectedUrl!.path, "url의 path와 일치합니다")
+        XCTAssertEqual(url.queryItems?.count, expectedUrl?.queryItems?.count, "url의 query의 수가 일치합니다")
+        XCTAssertEqual(url.scheme, expectedUrl?.scheme, "url의 scheme이 일치합니다")
+    }
+    
+    func testMakeTagCategoryRequestUrl() {
+        // given
+        let queryParams: [String: String] = [
+            "size": "\(12)",
+            "page": "\(0)",
+            "sort": "tagName"
+        ]
+        let expectedUrl = Endpoint.makeURL(with: queryParams, path: .fetchTagCategory)
+        // when
+        let url = Endpoint.tagCategoryFetch(withSize: 12, page: 0)
+        
+        // then
+        XCTAssertEqual(expectedUrl, url, "query를 이용한 정상적인 URL 생성했습니다.")
+    }
 }
 
 extension PhotoTagTests {


### PR DESCRIPTION
## 구현한 부분
- CollectionView를Pinterest 형식(2개의 Cell이 한 행에 표시 & 사진 높이에 따른 Dynamic height)
  - CollectionView Custom Layout 구현
-  DataSource
- Network
- ImageLoadTaskManager
- 
## 추가 구현해야 하는 부분 (노트 생성, 수정, 삭제 진행 후 재구현)
- 무한 스크롤 요청 부분 확인 필요
- API에 요청한 데이터가 업데이트 되었을 때 CollectionView 전체를 reloadData하지 말고 UICollectionViewDiffableDataSource 이용하기
- 태그 Cell에 들어갈 이미지 -> Dispatch Group 알아보기
- 다른 화면에 갔다가 다시 돌아왔을 때 다시 데이터를 요청해 표시하기 -> Notification 이용

-> 추가 구현사항은 추후 피드백 반영하여 새로운 브랜치로 구현. 

### 관련 이슈 
#29 #30 