### PR TITLE
태그 카테고리 View + Network 구현

### DIFF
--- a/PhotoTag/PhotoTag.xcodeproj/project.pbxproj
+++ b/PhotoTag/PhotoTag.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		6AC93F4A25B2D87A00882A12 /* PhotoNoteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEB5549259CB2640044699D /* PhotoNoteViewModel.swift */; };
 		6AC93F4D25B2D88000882A12 /* NoteNetworkingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0A216725AAC158009D56DE /* NoteNetworkingManager.swift */; };
 		6AC93F5025B2D88400882A12 /* NoteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7BB41825A0B111009D7F51 /* NoteViewController.swift */; };
+		6AC93F5425B3F74A00882A12 /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC93F5325B3F74A00882A12 /* Array.swift */; };
 		6ACCADBD256E28BE00072290 /* Hashtags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ACCADBC256E28BE00072290 /* Hashtags.swift */; };
 		6AD3ED5D25519F5700F8EF61 /* URLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD3ED5C25519F5700F8EF61 /* URLRequest.swift */; };
 		6AD3ED6225519F9E00F8EF61 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD3ED6125519F9E00F8EF61 /* NetworkManager.swift */; };
@@ -221,6 +222,7 @@
 		6AB83AF325442B370065B698 /* TagCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCoordinator.swift; sourceTree = "<group>"; };
 		6AB83AF825442C030065B698 /* TagCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCategoryViewController.swift; sourceTree = "<group>"; };
 		6AC73CF625A9DE7F00118E4D /* NoteViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NoteViewController.xib; sourceTree = "<group>"; };
+		6AC93F5325B3F74A00882A12 /* Array.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Array.swift; sourceTree = "<group>"; };
 		6ACCADBC256E28BE00072290 /* Hashtags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hashtags.swift; sourceTree = "<group>"; };
 		6AD3ED5C25519F5700F8EF61 /* URLRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRequest.swift; sourceTree = "<group>"; };
 		6AD3ED6125519F9E00F8EF61 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
@@ -381,6 +383,7 @@
 				6AD3ED5C25519F5700F8EF61 /* URLRequest.swift */,
 				6AAB872125849A1B00D1F3B1 /* NotificationName.swift */,
 				6AEC28AD259223CC00D0634A /* URLComponents.swift */,
+				6AC93F5325B3F74A00882A12 /* Array.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -836,6 +839,7 @@
 				6A87E25E258C7B4000896BD6 /* MockTags.swift in Sources */,
 				6A4F23F72546EC8A00577718 /* PhotoNoteListViewController.swift in Sources */,
 				6A5544DC2559B3BB003F3864 /* ContentView.swift in Sources */,
+				6AC93F5425B3F74A00882A12 /* Array.swift in Sources */,
 				6A0A216825AAC158009D56DE /* NoteNetworkingManager.swift in Sources */,
 				6A63BA1A255C1ED40096A0F7 /* TagManagementTableViewDataSource.swift in Sources */,
 				6A343C7B25735C7000146AAF /* Observable.swift in Sources */,

--- a/PhotoTag/PhotoTag.xcodeproj/project.pbxproj
+++ b/PhotoTag/PhotoTag.xcodeproj/project.pbxproj
@@ -114,6 +114,10 @@
 		6AB83AF425442B370065B698 /* TagCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AB83AF325442B370065B698 /* TagCoordinator.swift */; };
 		6AB83AF925442C030065B698 /* TagCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AB83AF825442C030065B698 /* TagCategoryViewController.swift */; };
 		6AC73CF725A9DE7F00118E4D /* NoteViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6AC73CF625A9DE7F00118E4D /* NoteViewController.xib */; };
+		6AC93F4725B2D86600882A12 /* AlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEB5544259CA8220044699D /* AlertView.swift */; };
+		6AC93F4A25B2D87A00882A12 /* PhotoNoteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEB5549259CB2640044699D /* PhotoNoteViewModel.swift */; };
+		6AC93F4D25B2D88000882A12 /* NoteNetworkingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0A216725AAC158009D56DE /* NoteNetworkingManager.swift */; };
+		6AC93F5025B2D88400882A12 /* NoteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7BB41825A0B111009D7F51 /* NoteViewController.swift */; };
 		6ACCADBD256E28BE00072290 /* Hashtags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ACCADBC256E28BE00072290 /* Hashtags.swift */; };
 		6AD3ED5D25519F5700F8EF61 /* URLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD3ED5C25519F5700F8EF61 /* URLRequest.swift */; };
 		6AD3ED6225519F9E00F8EF61 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD3ED6125519F9E00F8EF61 /* NetworkManager.swift */; };
@@ -879,6 +883,7 @@
 				6A4AD165258A5A1D00857FEC /* NetworkError.swift in Sources */,
 				6AEB5568259CB4B90044699D /* PhotoNoteViewController.swift in Sources */,
 				6A4AD159258A5A0200857FEC /* Endpoint.swift in Sources */,
+				6AC93F4725B2D86600882A12 /* AlertView.swift in Sources */,
 				6A4AD141258A59C200857FEC /* TagManagementTableViewDataSource.swift in Sources */,
 				6A4AD1F8258A5B9200857FEC /* LoginManager.swift in Sources */,
 				6A4AD1E8258A5B6600857FEC /* TagCategoryView.swift in Sources */,
@@ -922,15 +927,18 @@
 				6A4AD195258A5AE000857FEC /* CGFloat.swift in Sources */,
 				6A4AD1D8258A5B3A00857FEC /* SearchViewController.swift in Sources */,
 				6A4AD199258A5AE200857FEC /* UIImage.swift in Sources */,
+				6AC93F5025B2D88400882A12 /* NoteViewController.swift in Sources */,
 				6AAB8742258A205000D1F3B1 /* Hashtags.swift in Sources */,
 				6AFE3C1B253EDF3400B385AC /* PhotoTagTests.swift in Sources */,
 				6A4AD1DC258A5B3E00857FEC /* SelectPeriodViewController.swift in Sources */,
 				6A4AD18D258A5ADB00857FEC /* UIColor.swift in Sources */,
 				6A4AD161258A5A1800857FEC /* HTTPMethod.swift in Sources */,
+				6AC93F4A25B2D87A00882A12 /* PhotoNoteViewModel.swift in Sources */,
 				6A4AD191258A5ADD00857FEC /* UIView.swift in Sources */,
 				6A4AD1E4258A5B5000857FEC /* PhotoNoteListView.swift in Sources */,
 				6A4AD15D258A5A1300857FEC /* NetworkManager.swift in Sources */,
 				6A4AD1FC258A5B9800857FEC /* LoginView.swift in Sources */,
+				6AC93F4D25B2D88000882A12 /* NoteNetworkingManager.swift in Sources */,
 				6A4AD145258A59C600857FEC /* TagManagementTableViewDelegate.swift in Sources */,
 				6A4AD14D258A59D100857FEC /* TagManagementView.swift in Sources */,
 			);

--- a/PhotoTag/PhotoTag/Login/View/LoginViewController.swift
+++ b/PhotoTag/PhotoTag/Login/View/LoginViewController.swift
@@ -10,6 +10,7 @@ import AuthenticationServices
 
 enum UserDefaultKey {
     static let key = "userId"
+    static let selectedTagIds = "selectedTagIds"
 }
 
 final class LoginViewController: UIViewController {

--- a/PhotoTag/PhotoTag/Network/Endpoint.swift
+++ b/PhotoTag/PhotoTag/Network/Endpoint.swift
@@ -69,7 +69,7 @@ struct Endpoint: RequestProviding {
         var urlComponents = URLComponents()
         urlComponents.scheme = "http"
         urlComponents.host = "52.78.129.236"
-        urlComponents.path = ":8080" + path.description
+        urlComponents.path = path.description
         urlComponents.setQueryItems(with: parameters)
         return urlComponents
     }

--- a/PhotoTag/PhotoTag/Network/ImageLoadTaskManager.swift
+++ b/PhotoTag/PhotoTag/Network/ImageLoadTaskManager.swift
@@ -7,16 +7,18 @@
 
 import Foundation
 import Combine
+import UIKit.UIImage
 
 final class ImageLoadTaskManager {
     
-    func fetchImage(with url: URL, completionHandler: @escaping (Data?) -> Void) {
-        UseCase.shared.request(type: Data.self, imageUrl: url)
-            .receive(subscriber: Subscribers.Sink(receiveCompletion: { [weak self] in
-                guard case let .failure(error) = $0 else { return }
-                debugPrint(error.localizedDescription)
-            }, receiveValue: { [weak self] data in
-                completionHandler(data)
-            }))
+    func fetchImage(with imageURL: URL, completionHandler: @escaping (UIImage?) -> Void) {
+        
+        NetworkManager.shared.session.dataTask(with: imageURL) { (data, response, error) in
+            guard let data = data else { print("no image data"); return }
+            guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) else {
+                print("network error: \(error?.localizedDescription)"); return }
+            guard let image = UIImage(data: data) else { return }
+            completionHandler(image)
+        }
     }
 }

--- a/PhotoTag/PhotoTag/Network/ImageLoadTaskManager.swift
+++ b/PhotoTag/PhotoTag/Network/ImageLoadTaskManager.swift
@@ -15,10 +15,14 @@ final class ImageLoadTaskManager {
         
         NetworkManager.shared.session.dataTask(with: imageURL) { (data, response, error) in
             guard let data = data else { print("no image data"); return }
-            guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) else {
+            
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200...299).contains(httpResponse.statusCode) else {
                 print("network error: \(error?.localizedDescription)"); return }
+            
             guard let image = UIImage(data: data) else { return }
+            
             completionHandler(image)
-        }
+        }.resume()
     }
 }

--- a/PhotoTag/PhotoTag/Network/UseCase.swift
+++ b/PhotoTag/PhotoTag/Network/UseCase.swift
@@ -40,8 +40,7 @@ struct UseCase {
     
     // send file
     func request(_ network: NetworkConnectable = NetworkManager.shared,
-//                               data: Data,
-                               request: URLRequest) -> AnyPublisher<HTTPURLResponse, NetworkError> {
+                 request: URLRequest) -> AnyPublisher<HTTPURLResponse, NetworkError> {
         return network
             .request(request: request)
             .compactMap { $0.response as? HTTPURLResponse }
@@ -61,18 +60,6 @@ struct UseCase {
             .dataTaskPublisher(for: URLRequest(urlWithToken: url, method: method))
             .map { $0.data }
             .decode(type: D.self, decoder: decoder)
-            .eraseToAnyPublisher()
-    }
-    
-    // for fetch image
-    func request<I: Decodable>(_ network: NetworkConnectable = NetworkManager.shared,
-                               type: I.Type, imageUrl: URL) -> AnyPublisher<I, Error> {
-
-        return network
-            .session
-            .dataTaskPublisher(for: URLRequest(url: imageUrl))
-            .map { $0.data }
-            .decode(type: I.self, decoder: decoder)
             .eraseToAnyPublisher()
     }
     

--- a/PhotoTag/PhotoTag/Photo Note/Model/NoteNetworkingManager.swift
+++ b/PhotoTag/PhotoTag/Photo Note/Model/NoteNetworkingManager.swift
@@ -35,7 +35,7 @@ final class NoteNetworkingManager {
         // photo Image Data
         for image in images {
             guard let imageData = image.jpegData(compressionQuality: 0.1) else { return }
-            httpBody.append(convertFileData(fieldName: "file", fileName: "photo.jpg", mimeType: "multipart/form-data", fileData: imageData, using: boundary))
+            httpBody.append(convertFileData(fieldName: "file", fileName: "\(Date())_photo.jpg", mimeType: "multipart/form-data", fileData: imageData, using: boundary))
         }
         httpBody.appendString("--\(boundary)--")  // add final boundary with the two trailing dashes
         request.httpBody = httpBody as Data

--- a/PhotoTag/PhotoTag/Tag/Model/Tag.swift
+++ b/PhotoTag/PhotoTag/Tag/Model/Tag.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Tag: Codable {
+struct Tag: Codable, Hashable {
     var thumbnail: String
     let frequency, tagID: Int
     let activated: Bool

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewCell.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewCell.swift
@@ -16,9 +16,9 @@ final class TagCategoryCollectionViewCell: UICollectionViewCell {
     @IBOutlet weak var contentStackView: UIStackView!
     private(set) var tagId: Int = 0
     override var isSelected: Bool {
-        didSet{
+        didSet {
             self.layer.cornerRadius = 5
-            cellContentView.backgroundColor = isSelected ? #colorLiteral(red: 0.9764705896, green: 0.850980401, blue: 0.5490196347, alpha: 1).withAlphaComponent(0.5) : .clear
+            cellContentView.backgroundColor = isSelected ? #colorLiteral(red: 0.9764705896, green: 0.850980401, blue: 0.5490196347, alpha: 1).withAlphaComponent(0.5) : .white
             self.contentView.backgroundColor = .clear
             self.backgroundColor = .clear
         }
@@ -26,6 +26,7 @@ final class TagCategoryCollectionViewCell: UICollectionViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
+        self.backgroundColor = .white
     }
     
     func updateTagId(_ id: Int) {

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewCell.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewCell.swift
@@ -14,6 +14,7 @@ final class TagCategoryCollectionViewCell: UICollectionViewCell {
     @IBOutlet weak var noteCountLabel: UILabel!
     @IBOutlet weak var cellContentView: UIView!
     @IBOutlet weak var contentStackView: UIStackView!
+    private(set) var tagId: Int = 0
     override var isSelected: Bool {
         didSet{
             self.layer.cornerRadius = 5
@@ -25,6 +26,10 @@ final class TagCategoryCollectionViewCell: UICollectionViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
+    }
+    
+    func updateTagId(_ id: Int) {
+        self.tagId = id
     }
     
     func fill(with tag: Tag) {

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewCell.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 final class TagCategoryCollectionViewCell: UICollectionViewCell {
-
+    
     @IBOutlet weak var latestImageView: UIImageView!
     @IBOutlet weak var tagNameLabel: UILabel!
     @IBOutlet weak var noteCountLabel: UILabel!
@@ -22,8 +22,14 @@ final class TagCategoryCollectionViewCell: UICollectionViewCell {
         noteCountLabel.text = "\(tag.frequency) note(s)"
     }
     
-    func fillImage(with image: UIImage) {
-        latestImageView.image = image
+    func fillImage(with image: UIImage?) {
+        DispatchQueue.main.async {
+            self.latestImageView.contentMode = .scaleToFill
+            if image == nil {
+                self.latestImageView.image = #imageLiteral(resourceName: "logo") // if there is no image, set default image
+            }
+            self.latestImageView.image = image
+        }
     }
-
+    
 }

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewCell.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewCell.swift
@@ -12,6 +12,16 @@ final class TagCategoryCollectionViewCell: UICollectionViewCell {
     @IBOutlet weak var latestImageView: UIImageView!
     @IBOutlet weak var tagNameLabel: UILabel!
     @IBOutlet weak var noteCountLabel: UILabel!
+    @IBOutlet weak var cellContentView: UIView!
+    @IBOutlet weak var contentStackView: UIStackView!
+    override var isSelected: Bool {
+        didSet{
+            self.layer.cornerRadius = 5
+            cellContentView.backgroundColor = isSelected ? #colorLiteral(red: 0.9764705896, green: 0.850980401, blue: 0.5490196347, alpha: 1).withAlphaComponent(0.5) : .clear
+            self.contentView.backgroundColor = .clear
+            self.backgroundColor = .clear
+        }
+    }
     
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewCell.xib
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewCell.xib
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -19,18 +18,20 @@
                 <rect key="frame" x="0.0" y="0.0" width="273" height="286"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8jG-UG-N5I" userLabel="Content View">
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8jG-UG-N5I" userLabel="cell Content View">
                         <rect key="frame" x="0.0" y="0.0" width="273" height="286"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </view>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="jCz-Kx-zVf">
                         <rect key="frame" x="0.0" y="0.0" width="273" height="286"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" image="logo" translatesAutoresizingMaskIntoConstraints="NO" id="AGs-CZ-d3P" userLabel="Lastest Used Image View">
                                 <rect key="frame" x="0.0" y="0.0" width="273" height="245"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="752" text="#Sample_Tag" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VoZ-8k-crl" userLabel="Tag Name Label">
                                 <rect key="frame" x="0.0" y="245" width="273" height="20.5"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <color key="textColor" name="KeyColor"/>
                                 <nil key="highlightedColor"/>
@@ -40,25 +41,30 @@
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="253" verticalHuggingPriority="251" text=" - " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h1x-rP-lxH" userLabel="- Label">
                                         <rect key="frame" x="0.0" y="0.0" width="16.5" height="20.5"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="25" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pNr-O5-CPd" userLabel="Notes Count Label">
                                         <rect key="frame" x="16.5" y="0.0" width="20" height="20.5"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" notes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lfa-ar-OKI" userLabel="Unit Label">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" text=" notes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lfa-ar-OKI" userLabel="Unit Label">
                                         <rect key="frame" x="36.5" y="0.0" width="236.5" height="20.5"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </stackView>
                         </subviews>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </stackView>
                 </subviews>
             </view>
@@ -75,11 +81,13 @@
             </constraints>
             <size key="customSize" width="273" height="286"/>
             <connections>
+                <outlet property="cellContentView" destination="8jG-UG-N5I" id="ALT-Ka-hlr"/>
+                <outlet property="contentStackView" destination="jCz-Kx-zVf" id="FHO-Xd-2VI"/>
                 <outlet property="latestImageView" destination="AGs-CZ-d3P" id="9cy-bS-Wsw"/>
                 <outlet property="noteCountLabel" destination="pNr-O5-CPd" id="Ia5-b4-sLt"/>
                 <outlet property="tagNameLabel" destination="VoZ-8k-crl" id="70n-fR-Kff"/>
             </connections>
-            <point key="canvasLocation" x="348.55072463768118" y="147.32142857142856"/>
+            <point key="canvasLocation" x="348.55072463768118" y="145.98214285714286"/>
         </collectionViewCell>
     </objects>
     <resources>
@@ -87,8 +95,5 @@
         <namedColor name="KeyColor">
             <color red="0.37200000882148743" green="0.31499999761581421" blue="0.75999999046325684" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
     </resources>
 </document>

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewDataSource.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewDataSource.swift
@@ -25,6 +25,8 @@ final class TagCategoryCollectionViewDataSource: NSObject, UICollectionViewDataS
         bind(with: collectionViewCell)
         let tagInCurrentPosition = indexPath.item
         if !viewModel.tags.value.isEmpty && !viewModel.tagImageUrls.value.isEmpty {
+            let id = viewModel.tags.value[tagInCurrentPosition].tagID
+            collectionViewCell.updateTagId(id)
             collectionViewCell.fill(with: self.viewModel.tags.value[tagInCurrentPosition])
             viewModel.fetchTagImage(with: viewModel.tagImageUrls.value[tagInCurrentPosition]) { cellImage in
                 collectionViewCell.fillImage(with: cellImage)

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewDataSource.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewDataSource.swift
@@ -10,6 +10,7 @@ import UIKit
 final class TagCategoryCollectionViewDataSource: NSObject, UICollectionViewDataSource {
     
     private var viewModel = TagCategoryViewModel()
+    private let imageLoadTaskManager = ImageLoadTaskManager()
     
     func numberOfSections(in collectionView: UICollectionView) -> Int {
         return TagCategoryCollectionViewConstant.numberOfSections
@@ -22,11 +23,14 @@ final class TagCategoryCollectionViewDataSource: NSObject, UICollectionViewDataS
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let collectionViewCell = collectionView.dequeueReusableCell(with: TagCategoryCollectionViewCell.self, for: indexPath)
         bind(with: collectionViewCell)
-        let tagInCurrentPosition = self.viewModel.tags.value[indexPath.item]
-        if viewModel.tags.value.count != 0 {
-            collectionViewCell.fill(with: tagInCurrentPosition)
-            collectionViewCell.fillImage(with: viewModel.tagImages.value[indexPath.item])
+        let tagInCurrentPosition = indexPath.item
+        if !viewModel.tags.value.isEmpty && !viewModel.tagImageUrls.value.isEmpty {
+            collectionViewCell.fill(with: self.viewModel.tags.value[tagInCurrentPosition])
+            viewModel.fetchTagImage(with: viewModel.tagImageUrls.value[tagInCurrentPosition]) { cellImage in
+                collectionViewCell.fillImage(with: cellImage)
+            }
         }
+        collectionViewCell.backgroundColor = .black
         return collectionViewCell
     }
     

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewDataSource.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryCollectionViewDataSource.swift
@@ -22,9 +22,10 @@ final class TagCategoryCollectionViewDataSource: NSObject, UICollectionViewDataS
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let collectionViewCell = collectionView.dequeueReusableCell(with: TagCategoryCollectionViewCell.self, for: indexPath)
         bind(with: collectionViewCell)
-        if viewModel.tags.value.count != 0, self.viewModel.tagImages.value.count != 0 {
-            collectionViewCell.fill(with: self.viewModel.tags.value[indexPath.item])
-            collectionViewCell.fillImage(with: self.viewModel.tagImages.value[indexPath.item])
+        let tagInCurrentPosition = self.viewModel.tags.value[indexPath.item]
+        if viewModel.tags.value.count != 0 {
+            collectionViewCell.fill(with: tagInCurrentPosition)
+            collectionViewCell.fillImage(with: viewModel.tagImages.value[indexPath.item])
         }
         return collectionViewCell
     }
@@ -33,6 +34,7 @@ final class TagCategoryCollectionViewDataSource: NSObject, UICollectionViewDataS
 
 extension TagCategoryCollectionViewDataSource {
     func updateViewModel(updatedViewModel: TagCategoryViewModel) {
+        self.viewModel = updatedViewModel
     }
     
     private func bind(with cell: TagCategoryCollectionViewCell) {

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryView.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryView.swift
@@ -113,9 +113,10 @@ private extension TagCategoryView {
             let button = UIButton()
             button.setTitle(TagCategoryViewConstant.goButtonTitle, for: .normal)
             button.clipsToBounds = false
+            button.isUserInteractionEnabled = false
             button.layer.cornerRadius = .ten
-            button.backgroundColor = UIColor.keyColorInLightMode
-            button.setTitleColor(.white, for: .normal)
+            button.backgroundColor = UIColor.lightGray
+            button.setTitleColor(.black, for: .normal)
             return button
         }
         
@@ -125,6 +126,7 @@ private extension TagCategoryView {
             collectionView.register(cellType: TagCategoryCollectionViewCell.self)
             collectionView.contentInset = UIEdgeInsets(top: 23, left: 16, bottom: 10, right: 16)
             collectionView.backgroundColor = .clear
+            collectionView.allowsMultipleSelection = true
             return collectionView
         }
         

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryViewController.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryViewController.swift
@@ -161,7 +161,8 @@ extension TagCategoryViewController: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
-        return (collectionView.indexPathsForSelectedItems?.count ?? 0) < 4
+        guard let count = collectionView.indexPathsForSelectedItems?.count else { return true }
+        return count < 3
     }
 }
 

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryViewController.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryViewController.swift
@@ -47,9 +47,10 @@ final class TagCategoryViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         bind()
+        //        setupNotification()
+        fetchTags()
         configure()
         viewAppeared = true
-        fetchTags()
     }
     
     // MARK: - Functions
@@ -95,21 +96,15 @@ final class TagCategoryViewController: UIViewController {
     private func fetchTags() {
         if viewAppeared {
             viewModel.fetchTags(size: requestTagDataSize, page: requestTagDataPageNumber) { fetchedViewModel in
-                // fetch images here to determine cell heights in custom layout (TagCategoryLayoutDelegate)
-                self.viewModel.fetchTagImage(with: fetchedViewModel.tags.value) { [self] tagImages in
-                    fetchedViewModel.tagImages.value.append(contentsOf: tagImages)
-                    fetchedViewModel.tagImages.value = Array(Set(fetchedViewModel.tagImages.value)) // remove duplicate values
-                    self.saveTagImageHeight(tagImages)
-                    self.dataSource.updateViewModel(updatedViewModel: fetchedViewModel)
-                    self.updateTags()
-                }
+                self.dataSource.updateViewModel(updatedViewModel: fetchedViewModel)
+                self.updateTags()
             }
         }
     }
-        
+    
     private func saveTagImageHeight(_ images: [UIImage]) {
         let heights = images.map {$0.size.height}
-        tagImageHeights.append(contentsOf: Array(Set(heights)))
+        tagImageHeights.append(contentsOf: heights)
     }
     
     private func updateTags() {
@@ -154,6 +149,6 @@ extension TagCategoryViewController: UIScrollViewDelegate {
 
 extension TagCategoryViewController: TagCategoryLayoutDelegate {
     func collectionView(_ collectionView: UICollectionView, heightForPhotoAtIndexPath indexPath: IndexPath) -> CGFloat {
-        return self.tagImageHeights[indexPath.item]
+        return self.viewModel.tagImages.value[indexPath.item].size.height
     }
 }

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryViewController.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryViewController.swift
@@ -23,6 +23,7 @@ final class TagCategoryViewController: UIViewController {
     private var requestTagDataPageNumber: Int { return requestTagDataSize * requestTime }
     private var viewAppeared = false
     private var tagImageHeights: [CGFloat] = []
+    private var tagCategoryView: TagCategoryView! { return view as? TagCategoryView  }
     private var selectedTagIds: [Int] = [] {
         didSet {
             if selectedTagIds.count > 0 || selectedTagIds.count > 3 {
@@ -32,8 +33,6 @@ final class TagCategoryViewController: UIViewController {
             }
         }
     }
-    
-    private var tagCategoryView: TagCategoryView! { return view as? TagCategoryView  }
     
     // MARK: - Intialization
     //TODO:- add viewModel as parameter
@@ -139,6 +138,7 @@ extension TagCategoryViewController: TagCategoryViewDelegate {
     }
     
     func moveToPhotoListButtonDidTouched(_ tagCategoryView: TagCategoryView) {
+        UserDefaults.standard.set(selectedTagIds, forKey: UserDefaultKey.selectedTagIds)
         navigateToPhotoNoteList()
     }
     
@@ -152,12 +152,12 @@ extension TagCategoryViewController: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let collectionViewCell = collectionView.dequeueReusableCell(with: TagCategoryCollectionViewCell.self, for: indexPath)
-        self.selectedTagIds.append(indexPath.item)
+        self.selectedTagIds.append(collectionViewCell.tagId)
     }
     
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         let collectionViewCell = collectionView.dequeueReusableCell(with: TagCategoryCollectionViewCell.self, for: indexPath)
-        self.selectedTagIds = self.selectedTagIds.filter { $0 != indexPath.item }
+        self.selectedTagIds = self.selectedTagIds.filter { $0 != collectionViewCell.tagId }
     }
     
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryViewController.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryViewController.swift
@@ -20,14 +20,20 @@ final class TagCategoryViewController: UIViewController {
     private let viewModel: TagCategoryViewModel
     private let requestTagDataSize = 12
     private var requestTime = 0
-    private var requestTagDataPageNumber: Int {
-        return requestTagDataSize * requestTime
-    }
+    private var requestTagDataPageNumber: Int { return requestTagDataSize * requestTime }
     private var viewAppeared = false
     private var tagImageHeights: [CGFloat] = []
-    private var tagCategoryView: TagCategoryView! {
-        return view as? TagCategoryView
+    private var selectedTagIds: [Int] = [] {
+        didSet {
+            if selectedTagIds.count > 0 || selectedTagIds.count > 3 {
+                activateButton()
+            } else {
+                deactivateButton()
+            }
+        }
     }
+    
+    private var tagCategoryView: TagCategoryView! { return view as? TagCategoryView  }
     
     // MARK: - Intialization
     //TODO:- add viewModel as parameter
@@ -47,7 +53,6 @@ final class TagCategoryViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         bind()
-        //        setupNotification()
         fetchTags()
         configure()
         viewAppeared = true
@@ -95,7 +100,8 @@ final class TagCategoryViewController: UIViewController {
     
     private func fetchTags() {
         if viewAppeared {
-            viewModel.fetchTags(size: requestTagDataSize, page: requestTagDataPageNumber) { fetchedViewModel in
+            viewModel.fetchTags(size: requestTagDataSize,
+                                page: requestTagDataPageNumber) { fetchedViewModel in
                 self.dataSource.updateViewModel(updatedViewModel: fetchedViewModel)
                 self.updateTags()
             }
@@ -114,6 +120,17 @@ final class TagCategoryViewController: UIViewController {
         }
     }
     
+    private func activateButton() {
+        tagCategoryView.moveToPhotoListButton.isUserInteractionEnabled = true
+        tagCategoryView.moveToPhotoListButton.backgroundColor = UIColor.keyColorInLightMode
+        tagCategoryView.moveToPhotoListButton.setTitleColor(.white, for: .normal)
+    }
+    
+    private func deactivateButton() {
+        tagCategoryView.moveToPhotoListButton.isUserInteractionEnabled = false
+        tagCategoryView.moveToPhotoListButton.backgroundColor = UIColor.lightGray
+        tagCategoryView.moveToPhotoListButton.setTitleColor(.black, for: .normal)
+    }
 }
 
 extension TagCategoryViewController: TagCategoryViewDelegate {
@@ -131,6 +148,20 @@ extension TagCategoryViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let itemSize = (collectionView.frame.width - (collectionView.contentInset.left + collectionView.contentInset.right + 10)) / 2
         return CGSize(width: itemSize, height: itemSize)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let collectionViewCell = collectionView.dequeueReusableCell(with: TagCategoryCollectionViewCell.self, for: indexPath)
+        self.selectedTagIds.append(indexPath.item)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+        let collectionViewCell = collectionView.dequeueReusableCell(with: TagCategoryCollectionViewCell.self, for: indexPath)
+        self.selectedTagIds = self.selectedTagIds.filter { $0 != indexPath.item }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        return (collectionView.indexPathsForSelectedItems?.count ?? 0) < 4
     }
 }
 

--- a/PhotoTag/PhotoTag/Utility/Extension/Array.swift
+++ b/PhotoTag/PhotoTag/Utility/Extension/Array.swift
@@ -1,0 +1,25 @@
+//
+//  Array.swift
+//  PhotoTag
+//
+//  Created by Keunna Lee on 2021/01/17.
+//
+
+import Foundation
+
+extension Array where Element: Hashable {
+   
+  /// 순서는 그대로, 중복 값만 삭제
+  var uniques: Array {
+    var buffer = Array()
+    var added = Set<Element>()
+    for elem in self {
+      if !added.contains(elem) {
+        buffer.append(elem)
+        added.insert(elem)
+      }
+    }
+    return buffer
+  }
+   
+}

--- a/PhotoTag/PhotoTagTests/PhotoTagTests.swift
+++ b/PhotoTag/PhotoTagTests/PhotoTagTests.swift
@@ -12,6 +12,24 @@ import Combine
 
 class PhotoTagTests: XCTestCase {
     
+    // MARK: - Tests for fetch Image
+    
+    func testRequestImage() {
+        //given
+        let expectation = XCTestExpectation(description: "image download is completed")
+        //when
+        guard let imageUrl =
+                URL(string: "https://cdn.pixabay.com/photo/2020/11/22/16/45/nutcracker-5767159_1280.jpg") else { return }
+        //then
+        let dataTask = URLSession.shared.dataTask(with: imageUrl) { (data, _, _) in
+            
+            XCTAssertNotNil(data, "No data was downloaded.")
+            expectation.fulfill()
+        }
+        dataTask.resume()
+        wait(for: [expectation], timeout: 10.0)
+    }
+  
     // MARK: - Tests for TagManagementViewModel
     
     func testUpdatedHashtagCount() {


### PR DESCRIPTION
### 구현 기능
1. 활성화 태그 목록 카테고리로 표시
2. 태그가 쓰인 노트 중 가장 최근에 사용된 노트의 이미지를 표시
3. 최대 3개의 태그 선택 가능
4. 최소 1개 이상, 최대 3개 태그를 선택했을 경우 다음 화면으로 가는 버튼 활성화
5. 태그 선택시 배경색 변경
6. API에서 받아온 태그 데이터(섬네일, 태그이름, 사용노트 수) 각 Cell에 표시
7. 시간을 이용하여 파일 업로드시 이미지 파일 이름 설정
8. 선택한 태그(들)의 태그 아이디를 UserDefualt에 저장 -> 다음 화면에서 선택된 태그에 대한 노트만 요청하기 위해
9. 이미지 요청(network) 테스트 케이스 추가

동작화면 gif를 추가할 예정입니다.
아직 작성중입니다.

관련 이슈: #29 #30