### PR TITLE
노트 작성시 이미지 기반 추천 태그 표시

### DIFF
--- a/PhotoTag/PhotoTag.xcodeproj/project.pbxproj
+++ b/PhotoTag/PhotoTag.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		6AD3ED6725519FE900F8EF61 /* UseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD3ED6625519FE900F8EF61 /* UseCase.swift */; };
 		6AD3ED6C2551A09900F8EF61 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD3ED6B2551A09900F8EF61 /* HTTPMethod.swift */; };
 		6AD3ED712551A0B400F8EF61 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD3ED702551A0B400F8EF61 /* NetworkError.swift */; };
+		6AD8DAB225BDB63D003205C0 /* TagSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD8DAB125BDB63D003205C0 /* TagSuggestion.swift */; };
 		6AE1245E256830A300291388 /* UISwipeGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE1245D256830A300291388 /* UISwipeGestureRecognizer.swift */; };
 		6AEB5545259CA8220044699D /* AlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEB5544259CA8220044699D /* AlertView.swift */; };
 		6AEB554A259CB2640044699D /* PhotoNoteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEB5549259CB2640044699D /* PhotoNoteViewModel.swift */; };
@@ -252,6 +253,7 @@
 		6AD3ED6625519FE900F8EF61 /* UseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UseCase.swift; sourceTree = "<group>"; };
 		6AD3ED6B2551A09900F8EF61 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		6AD3ED702551A0B400F8EF61 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		6AD8DAB125BDB63D003205C0 /* TagSuggestion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TagSuggestion.swift; sourceTree = "<group>"; };
 		6AE1245D256830A300291388 /* UISwipeGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UISwipeGestureRecognizer.swift; sourceTree = "<group>"; };
 		6AEB5544259CA8220044699D /* AlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertView.swift; sourceTree = "<group>"; };
 		6AEB5549259CB2640044699D /* PhotoNoteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoNoteViewModel.swift; sourceTree = "<group>"; };
@@ -314,6 +316,7 @@
 			children = (
 				6A0A216725AAC158009D56DE /* NoteNetworkingManager.swift */,
 				6AC3ED1D25B821EA0032FF29 /* PhotoNote.swift */,
+				6AD8DAB125BDB63D003205C0 /* TagSuggestion.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -918,6 +921,7 @@
 				6AAE725E2555988B00CF7F9F /* TagCategoryView.swift in Sources */,
 				6A57CAEF255ED33600E42348 /* UsesAutoLayout.swift in Sources */,
 				6A63BA2C255C2F210096A0F7 /* TagManagementTableViewDelegate.swift in Sources */,
+				6AD8DAB225BDB63D003205C0 /* TagSuggestion.swift in Sources */,
 				6A5544C925599CDF003F3864 /* UIColor.swift in Sources */,
 				6A5544E42559B3CA003F3864 /* ScrollableContentViewWithHeader.swift in Sources */,
 				6AEC28AE259223CC00D0634A /* URLComponents.swift in Sources */,

--- a/PhotoTag/PhotoTag/AppConfigurator/AppViewControllersFactory.swift
+++ b/PhotoTag/PhotoTag/AppConfigurator/AppViewControllersFactory.swift
@@ -31,8 +31,8 @@ struct AppViewControllersFactory {
         return SelectPhotoViewController(coordinator: coordinator)
     }
     
-    func writePhotoNoteViewController(coordinator: PhotoNoteCoordinator, with text: String) -> UIViewController {
-        let noteViewController = NoteViewController(coordinator: coordinator, with: text)
+    func writePhotoNoteViewController(coordinator: PhotoNoteCoordinator, with text: String, and photos: [NoteImage]) -> UIViewController {
+        let noteViewController = NoteViewController(coordinator: coordinator, with: text, and: photos)
         return noteViewController
     }
     

--- a/PhotoTag/PhotoTag/Coordinator/PhotoNoteCoordinator.swift
+++ b/PhotoTag/PhotoTag/Coordinator/PhotoNoteCoordinator.swift
@@ -24,8 +24,8 @@ final class PhotoNoteCoordinator: ChildCoordinator {
         navigationController.pushViewController(selectPhotoViewController, animated: true)
     }
     
-    func navigateToWritePhotoNote(with text: String) {
-        let writePhotoNoteViewController = appViewControllerFactory.writePhotoNoteViewController(coordinator: self, with: text)
+    func navigateToWritePhotoNote(with text: String, photos: [NoteImage]) {
+        let writePhotoNoteViewController = appViewControllerFactory.writePhotoNoteViewController(coordinator: self, with: text, and: photos)
         navigationController.pushViewController(writePhotoNoteViewController, animated: true)
     }
     

--- a/PhotoTag/PhotoTag/Network/Endpoint.swift
+++ b/PhotoTag/PhotoTag/Network/Endpoint.swift
@@ -24,6 +24,7 @@ struct Endpoint: RequestProviding {
         case createNote
         case fetchPhotoNoteList
         case fetchPhotoNote
+        case tagSuggestion
         
         var description: String {
             switch self {
@@ -34,6 +35,7 @@ struct Endpoint: RequestProviding {
             case .createNote: return "/notes"
             case .fetchPhotoNoteList: return "/tags"
             case .fetchPhotoNote: return "/notes/"
+            case .tagSuggestion: return "/suggestion"
             }
         }
     }

--- a/PhotoTag/PhotoTag/Network/UseCase.swift
+++ b/PhotoTag/PhotoTag/Network/UseCase.swift
@@ -65,13 +65,24 @@ struct UseCase {
             .eraseToAnyPublisher()
     }
     
-    // send file
+    // send file (send file and return HTTPURLResponse)
     func request(_ network: NetworkConnectable = NetworkManager.shared,
                  request: URLRequest) -> AnyPublisher<HTTPURLResponse, NetworkError> {
         return network
             .request(request: request)
             .compactMap { $0.response as? HTTPURLResponse }
             .mapError { _ in NetworkError.jsonDecodingError }
+            .eraseToAnyPublisher()
+    }
+    
+    // tag suggestion (send file and return two string arrays)
+    func request(_ network: NetworkConnectable = NetworkManager.shared,
+                 urlRequest: URLRequest) -> AnyPublisher<TagSuggestion, Error> {
+        return network
+            .session
+            .dataTaskPublisher(for: urlRequest)
+            .map { $0.data }
+            .decode(type: TagSuggestion.self, decoder: decoder)
             .eraseToAnyPublisher()
     }
     

--- a/PhotoTag/PhotoTag/Photo Note/Model/TagSuggestion.swift
+++ b/PhotoTag/PhotoTag/Photo Note/Model/TagSuggestion.swift
@@ -1,0 +1,12 @@
+//
+//  TagSuggestion.swift
+//  Pods
+//
+//  Created by Keunna Lee on 2021/01/24.
+//
+
+import Foundation
+
+struct TagSuggestion: Codable {
+    let tagsEn, tagsKr: [String]
+}

--- a/PhotoTag/PhotoTag/Photo Note/PhotoNote/View/PhotoNoteViewController.swift
+++ b/PhotoTag/PhotoTag/Photo Note/PhotoNote/View/PhotoNoteViewController.swift
@@ -28,6 +28,7 @@ class PhotoNoteViewController: UIViewController {
     @IBOutlet weak var imageHorizontalScrollView: UIScrollView!
     private var noteState: NoteState
     private var noteContentText: NoteText = ""
+    private var tagNames: [TagName] = []
     private let noteNetworkManager = NoteNetworkingManager()
     
     init(coordinator: PhotoNoteCoordinator,
@@ -158,7 +159,7 @@ class PhotoNoteViewController: UIViewController {
     }
     
     @objc private func presentNoteWritingScene() {
-        coordinator?.navigateToWritePhotoNote(with: noteContentText)
+        coordinator?.navigateToWritePhotoNote(with: noteContentText, photos: viewModel.selectedImages.value)
     }
     
     @objc func saveNoteText(_ notification: Notification) {

--- a/PhotoTag/PhotoTag/Photo Note/PhotoNote/View/PhotoNoteViewController.xib
+++ b/PhotoTag/PhotoTag/Photo Note/PhotoNote/View/PhotoNoteViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -117,14 +117,14 @@
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Wxs-Mv-r2c">
                             <rect key="frame" x="10" y="0.0" width="394" height="235"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M4O-iK-5Lv" userLabel="date label">
-                                    <rect key="frame" x="0.0" y="0.0" width="394" height="20.5"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M4O-iK-5Lv" userLabel="date label">
+                                    <rect key="frame" x="0.0" y="0.0" width="394" height="50"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="ddu-1g-Zcf" userLabel="note text view">
-                                    <rect key="frame" x="0.0" y="20.5" width="394" height="214.5"/>
+                                    <rect key="frame" x="0.0" y="50" width="394" height="185"/>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     <color key="textColor" systemColor="labelColor"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>

--- a/PhotoTag/PhotoTag/Photo Note/PhotoNoteList/ViewModel/PhotoNoteListViewModel.swift
+++ b/PhotoTag/PhotoTag/Photo Note/PhotoNoteList/ViewModel/PhotoNoteListViewModel.swift
@@ -30,9 +30,6 @@ class PhotoNoteListViewModel {
         noteNetworkingManager.fetchNoteList(tagIds: selectedTags) { photoList in
             guard let allPhotoList = photoList else { return }
             self.photoNoteList.value = allPhotoList
-            self.firstSelectedTagText.value = self.photoNoteList.value[0].tags[0]
-            self.secondSelectedTagText.value = self.photoNoteList.value[1].tags[0]
-            self.thirdSelectedTagText.value = self.photoNoteList.value[2].tags[0]
             completionHandler(allPhotoList)
         }
     }

--- a/PhotoTag/PhotoTag/Tag/Model/TagNetworkingManager.swift
+++ b/PhotoTag/PhotoTag/Tag/Model/TagNetworkingManager.swift
@@ -26,7 +26,7 @@ final class TagNetworkingManager {
             }))
     }
     
-    func updateHashtagActivatedState(of tagId: Int, with data: HastagState) {
+    func updateHashtagActivatedState(of tagId: TagID, with data: HastagState) {
         UseCase.shared.request(data: data,
                                endpoint: Endpoint.hashtagPatch(path: .patchHashtags, tagId: tagId),
                                method: .patch)

--- a/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryViewController.swift
+++ b/PhotoTag/PhotoTag/Tag/TagCategory/View/TagCategoryViewController.swift
@@ -55,6 +55,7 @@ final class TagCategoryViewController: UIViewController {
         fetchTags()
         configure()
         viewAppeared = true
+        activateButton()
     }
     
     // MARK: - Functions

--- a/PhotoTag/PhotoTag/Utility/Typealias.swift
+++ b/PhotoTag/PhotoTag/Utility/Typealias.swift
@@ -9,6 +9,7 @@ import Foundation
 import UIKit.UIImage
 
 // tag
+typealias TagName = String
 typealias TagID = Int
 typealias TagImage = UIImage
 


### PR DESCRIPTION
### 구현 내용
1. 노트 이미지를 API에 보낸 후 받아온 추천 태그 요청 (구현 중)
2. 키보드 상단에 추천 태그 표시.
  Keyboard Accessary View 이용
3.  Keyboard Accessary View에 표시된 추천 태그를 탭하면 노트 text 마지막에 추가
ex) 기존 노트 text: `작성중입니다.`
`#태그` 를 탭 했을 때 -> `작성중입니다. #태그`


### 현재 해결중인 문제
API 9번 - 태그 추천 관련 이슈
(현재 iOS 14)

```


Completion<Error>
  ▿ failure : URLError
    - _nsError : Error Domain=NSURLErrorDomain Code=-1103 "resource exceeds maximum size"
    -  UserInfo={NSUnderlyingError=0x6000032beaf0 {Error Domain=kCFErrorDomainCFNetwork Code=-1103 "(null)"}, 
    - NSErrorFailingURLStringKey=http://52.78.129.236/suggestion, 
    - NSErrorFailingURLKey=http://52.78.129.236/suggestion, 
    - NSLocalizedDescription=resource exceeds maximum size}
```
https://stackoverflow.com/a/56973866

### 관련 이슈: #43

closes #43